### PR TITLE
feat: read-only user abilities (list-users, get-user)

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -4,15 +4,16 @@
 **Board:** [PlugPress HQ](https://github.com/orgs/plugpressco/projects/3)
 
 ## Last session
-2026-07-07 — P0 live verification round ([#4](https://github.com/plugpressco/saddle/issues/4)), mechanical half done:
-- Verified live on divi-dev: 116 abilities registered (free 50 + Divi 44 + Waggle 13 + Knovia 9 wrapped), tier gate, approval gate (preview → single-use token → reuse refused).
-- Found + fixed a real Pro bug the harness couldn't see: GlobalData/GlobalPreset stdClass trees broke variable edit/delete, created a bucket-wipe data-loss path, would fatal color edits on VB-written data (`saddle-pro@44e0324`).
-- Knovia + Waggle now symlinked and active on divi-dev.
-- Earlier: PLAN docs migrated to issues #9–#12; STATUS.md excluded from release zips.
+2026-07-10 — Roadmap replan + shipped Users read-only ([#13](https://github.com/plugpressco/saddle/issues/13)):
+- Scope is being replanned, so the buried Finalized-Plan (#12) items I'd broken out (#14 comments, #15 revision-restore, #16–#19 deferred Phase 3) were **closed as not-planned** — #12 still records the original intent if any needs reviving.
+- Built **#13**: two read-tier user abilities, `saddle/list-users` + `saddle/get-user`, in new `includes/abilities/users.php` (wired in bootstrap require + `wp_abilities_api_init` hook). Both gated on the `list_users` cap (admins only by default) on top of the read tier; PII (email/real name/login) revealed only to callers who can `edit_users`. list-users supports role filter, search, ordering, pagination (`{items,total,total_pages,page}` envelope). No create/update/delete — that surface stays out per the plan. Free ability count 50 → **52**.
+- New `tests/users-test.php` (10 tests, 49 assertions) drives the real `execute()` path: cap-gate denial for a subscriber, PII split, role filter, pagination, not-found. Full suite **244 green**; `includes/abilities/users.php` phpcs-clean; no eval/exec.
 
 ## Next up
-- Fahim: VB sanity check on divi-dev (global colors/variables panels) + the landing-page prompt vs 4/10 baseline — the judgment half of #4.
-- Then #4 closes and unblocks Rank Math (saddle-pro #1/#7) per the P0 rule.
+- **Not committed/pushed** — the #13 work is in the working tree only. Commit + tag when ready.
+- Live round-trip on a real site is the one remaining manual check for #13 (harness proves logic; a live `list-users`/`get-user` call over MCP confirms the transport surface).
+- Scope replan: decide the new Saddle direction before reopening any of the closed backlog (#14–#19).
 
 ## Blockers / open questions
-- Theme-builder writes unverified live (no create-template ability → only real templates to test against).
+- Saddle scope under active replanning — hold new feature work until the new plan lands.
+- (Prior) Theme-builder writes unverified live (no create-template ability → only real templates to test against).

--- a/includes/abilities/users.php
+++ b/includes/abilities/users.php
@@ -1,0 +1,204 @@
+<?php
+/**
+ * User abilities — read-only directory access (Phase 2, item 5).
+ *
+ * Reads only. There is deliberately NO create / update / delete on users here:
+ * that is a meaningfully higher-risk surface (privilege escalation) and is
+ * intentionally out of scope for this phase — see
+ * https://github.com/plugpressco/saddle/issues/13 and the Finalized Plan
+ * (#12, Phase 2 §5). If a user-mutation surface is ever added it gets its own
+ * scoped decision, not a default inclusion.
+ *
+ * Both abilities require the `list_users` capability — which, by default, only
+ * administrators hold — so surfacing the user directory is gated by capability
+ * on top of the read tier. Personally-identifying fields (email, real name,
+ * login) are returned ONLY to a caller who can `edit_users`; everyone else sees
+ * the public-facing profile only.
+ *
+ * @package Saddle
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Register the read-only user abilities. Hooked to `wp_abilities_api_init`.
+ */
+function saddle_register_user_abilities() {
+	wp_register_ability(
+		'saddle/list-users',
+		array(
+			'label'               => __( 'List users', 'saddle' ),
+			'description'         => __( 'Lists site users as summaries (id, name, slug, roles, registered date, avatar, published-post count). Read-only. Supports filtering by role and a search term, plus ordering and pagination via per_page/page. Email and real name are included only for callers who can edit users. There is no create, update, or delete — this surface is read-only.', 'saddle' ),
+			'category'            => 'saddle',
+			'input_schema'        => array(
+				'type'       => 'object',
+				'default'    => (object) array(),
+				'properties' => array(
+					'search'   => array(
+						'type'        => 'string',
+						'description' => __( 'Optional keyword filter (matches name, login, email, URL).', 'saddle' ),
+					),
+					'role'     => array(
+						'type'        => 'string',
+						'description' => __( 'Filter by role slug, e.g. "administrator", "editor", "author", "subscriber".', 'saddle' ),
+					),
+					'orderby'  => array(
+						'type'    => 'string',
+						'enum'    => array( 'registered', 'display_name', 'ID', 'post_count' ),
+						'default' => 'registered',
+					),
+					'order'    => array(
+						'type'    => 'string',
+						'enum'    => array( 'ASC', 'DESC' ),
+						'default' => 'DESC',
+					),
+					'per_page' => saddle_per_page_schema(),
+					'page'     => saddle_page_schema(),
+				),
+			),
+			'execute_callback'    => array( 'Saddle_User_Abilities', 'list_users' ),
+			'permission_callback' => Saddle_Capabilities::permission( 'read', 'list_users', 'list-users' ),
+			'meta'                => saddle_ability_meta( true, false, true, 'read' ),
+		)
+	);
+
+	wp_register_ability(
+		'saddle/get-user',
+		array(
+			'label'               => __( 'Get user', 'saddle' ),
+			'description'         => __( 'Returns a single user by id: name, slug, roles, registered date, avatar, bio, website, and published-post count. Read-only. Email, real name, and login are included only for callers who can edit users.', 'saddle' ),
+			'category'            => 'saddle',
+			'input_schema'        => saddle_id_schema( __( 'The user ID.', 'saddle' ) ),
+			'execute_callback'    => array( 'Saddle_User_Abilities', 'get_user' ),
+			'permission_callback' => Saddle_Capabilities::permission( 'read', 'list_users', 'get-user' ),
+			'meta'                => saddle_ability_meta( true, false, true, 'read' ),
+		)
+	);
+}
+
+/**
+ * Execute callbacks for the read-only user abilities.
+ *
+ * Every method assumes the permission_callback has already enforced an
+ * authenticated caller, the `list_users` capability, the read tier, the pause
+ * switch, and the per-ability toggle. These add only the shaping the generic
+ * gate can't: pagination bounds, the PII split, and safe field selection.
+ */
+class Saddle_User_Abilities {
+
+	/**
+	 * Orderby values accepted by list-users, all natively supported by
+	 * WP_User_Query. Anything else falls back to the default.
+	 */
+	const ORDERBY = array( 'registered', 'display_name', 'ID', 'post_count' );
+
+	/**
+	 * saddle/list-users.
+	 *
+	 * @param mixed $input Ability input.
+	 * @return array
+	 */
+	public static function list_users( $input = null ) {
+		$input = is_array( $input ) ? $input : array();
+
+		$per_page = isset( $input['per_page'] ) ? (int) $input['per_page'] : 20;
+		$per_page = max( 1, min( 100, $per_page ) );
+		$page     = isset( $input['page'] ) ? max( 1, (int) $input['page'] ) : 1;
+
+		$orderby = isset( $input['orderby'] ) && in_array( $input['orderby'], self::ORDERBY, true ) ? $input['orderby'] : 'registered';
+		$order   = isset( $input['order'] ) && 'ASC' === strtoupper( (string) $input['order'] ) ? 'ASC' : 'DESC';
+
+		$args = array(
+			'number'      => $per_page,
+			'paged'       => $page,
+			'orderby'     => $orderby,
+			'order'       => $order,
+			'count_total' => true,
+		);
+
+		if ( ! empty( $input['role'] ) && is_string( $input['role'] ) ) {
+			$args['role'] = $input['role'];
+		}
+		if ( ! empty( $input['search'] ) && is_string( $input['search'] ) ) {
+			// Wildcards so it matches substrings, like the core users list table.
+			$args['search']         = '*' . trim( $input['search'] ) . '*';
+			$args['search_columns'] = array( 'user_login', 'user_nicename', 'display_name', 'user_email', 'user_url' );
+		}
+
+		$query  = new WP_User_Query( $args );
+		$reveal = current_user_can( 'edit_users' );
+
+		$items = array();
+		foreach ( $query->get_results() as $user ) {
+			$items[] = self::format_user( $user, $reveal, false );
+		}
+
+		$total = (int) $query->get_total();
+
+		return array(
+			'items'       => $items,
+			'total'       => $total,
+			'total_pages' => (int) ceil( $total / $per_page ),
+			'page'        => $page,
+		);
+	}
+
+	/**
+	 * saddle/get-user.
+	 *
+	 * @param mixed $input Ability input { id }.
+	 * @return array|WP_Error
+	 */
+	public static function get_user( $input = null ) {
+		$input = is_array( $input ) ? $input : array();
+		$id    = isset( $input['id'] ) ? (int) $input['id'] : 0;
+		if ( $id < 1 ) {
+			return new WP_Error( 'saddle_missing_id', __( 'A user "id" is required.', 'saddle' ), array( 'status' => 400 ) );
+		}
+
+		$user = get_userdata( $id );
+		if ( ! $user ) {
+			return new WP_Error( 'saddle_not_found', __( 'No user with that ID.', 'saddle' ), array( 'status' => 404 ) );
+		}
+
+		return self::format_user( $user, current_user_can( 'edit_users' ), true );
+	}
+
+	/**
+	 * Shape a WP_User into the safe array returned to the agent.
+	 *
+	 * The base fields are the public-facing profile — the same surface a theme
+	 * already exposes on an author archive. PII (email, real name, login) is
+	 * added only when $reveal_pii is true, i.e. the caller can edit users.
+	 *
+	 * @param WP_User $user       The user.
+	 * @param bool    $reveal_pii Whether to include email / real name / login.
+	 * @param bool    $detailed   Whether to include bio + website (single-user view).
+	 * @return array
+	 */
+	private static function format_user( WP_User $user, $reveal_pii, $detailed ) {
+		$data = array(
+			'id'         => (int) $user->ID,
+			'name'       => $user->display_name,
+			'slug'       => $user->user_nicename,
+			'roles'      => array_values( (array) $user->roles ),
+			'registered' => $user->user_registered,
+			'avatar_url' => get_avatar_url( $user->ID ),
+			'post_count' => (int) count_user_posts( $user->ID, 'post', true ),
+		);
+
+		if ( $detailed ) {
+			$data['url'] = $user->user_url;
+			$data['bio'] = get_user_meta( $user->ID, 'description', true );
+		}
+
+		if ( $reveal_pii ) {
+			$data['email']      = $user->user_email;
+			$data['first_name'] = $user->first_name;
+			$data['last_name']  = $user->last_name;
+			$data['login']      = $user->user_login;
+		}
+
+		return $data;
+	}
+}

--- a/saddle.php
+++ b/saddle.php
@@ -103,6 +103,7 @@ final class Saddle {
 			require_once SADDLE_DIR . 'includes/abilities/core-content.php';
 			require_once SADDLE_DIR . 'includes/abilities/blocks.php';
 			require_once SADDLE_DIR . 'includes/abilities/site.php';
+			require_once SADDLE_DIR . 'includes/abilities/users.php';
 			require_once SADDLE_DIR . 'includes/abilities/context.php';
 			require_once SADDLE_DIR . 'includes/abilities/lint.php';
 			require_once SADDLE_DIR . 'includes/abilities/memory.php';
@@ -110,6 +111,7 @@ final class Saddle {
 			add_action( 'wp_abilities_api_init', 'saddle_register_abilities' );
 			add_action( 'wp_abilities_api_init', 'saddle_register_block_abilities' );
 			add_action( 'wp_abilities_api_init', 'saddle_register_site_abilities' );
+			add_action( 'wp_abilities_api_init', 'saddle_register_user_abilities' );
 			add_action( 'wp_abilities_api_init', 'saddle_register_context_abilities' );
 			add_action( 'wp_abilities_api_init', 'saddle_register_lint_abilities' );
 			add_action( 'wp_abilities_api_init', 'saddle_register_memory_abilities' );

--- a/tests/users-test.php
+++ b/tests/users-test.php
@@ -1,0 +1,181 @@
+<?php
+/**
+ * Read-only user ability tests.
+ *
+ * Drives the real wp_get_ability()->execute() path so the read tier, the
+ * `list_users` capability gate, the personally-identifying-field split, and the
+ * pagination/search shaping are all proven end to end.
+ *
+ * @package Saddle
+ */
+
+class Saddle_Users_Test extends WP_UnitTestCase {
+
+	private $admin;
+
+	public function set_up() {
+		parent::set_up();
+		$this->admin = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $this->admin );
+		// These abilities are read-tier; a fresh install is `read`, so this
+		// mirrors the real default rather than escalating for the test.
+		Saddle_Capabilities::set_tier( 'read' );
+	}
+
+	public function tear_down() {
+		delete_option( Saddle_Capabilities::OPTION );
+		delete_option( Saddle_Capabilities::DISABLED_OPTION );
+		delete_option( Saddle_Capabilities::PAUSED_OPTION );
+		parent::tear_down();
+	}
+
+	private function ability( $name ) {
+		$a = wp_get_ability( $name );
+		$this->assertNotNull( $a, "Ability {$name} must be registered." );
+		return $a;
+	}
+
+	/* -------- registration -------- */
+
+	public function test_user_abilities_are_registered() {
+		$this->assertNotNull( wp_get_ability( 'saddle/list-users' ) );
+		$this->assertNotNull( wp_get_ability( 'saddle/get-user' ) );
+	}
+
+	public function test_user_abilities_are_read_tier_and_readonly() {
+		foreach ( array( 'saddle/list-users', 'saddle/get-user' ) as $name ) {
+			$meta = $this->ability( $name )->get_meta();
+			$this->assertSame( 'read', $meta['saddle']['tier'], "{$name} must be read tier." );
+			$this->assertTrue( $meta['annotations']['readonly'], "{$name} must be readonly." );
+			$this->assertFalse( $meta['annotations']['destructive'], "{$name} must not be destructive." );
+		}
+	}
+
+	/* -------- capability gate -------- */
+
+	public function test_admin_can_list_at_read_tier() {
+		$result = $this->ability( 'saddle/list-users' )->execute( array() );
+		$this->assertIsArray( $result, 'An admin at the read tier can list users.' );
+		$this->assertArrayHasKey( 'items', $result );
+		$this->assertArrayHasKey( 'total', $result );
+	}
+
+	public function test_subscriber_without_list_users_is_denied() {
+		$subscriber = self::factory()->user->create( array( 'role' => 'subscriber' ) );
+		wp_set_current_user( $subscriber );
+
+		$this->assertFalse( current_user_can( 'list_users' ), 'Precondition: a subscriber lacks list_users.' );
+
+		$list = $this->ability( 'saddle/list-users' )->execute( array() );
+		$this->assertWPError( $list, 'list-users must be denied without the list_users capability.' );
+
+		$get = $this->ability( 'saddle/get-user' )->execute( array( 'id' => $this->admin ) );
+		$this->assertWPError( $get, 'get-user must be denied without the list_users capability.' );
+	}
+
+	/* -------- PII split -------- */
+
+	public function test_admin_sees_pii() {
+		$target = self::factory()->user->create(
+			array(
+				'role'       => 'author',
+				'user_email' => 'author@example.test',
+				'first_name' => 'Ada',
+				'last_name'  => 'Lovelace',
+			)
+		);
+
+		$result = $this->ability( 'saddle/get-user' )->execute( array( 'id' => $target ) );
+		$this->assertIsArray( $result );
+		$this->assertSame( 'author@example.test', $result['email'] );
+		$this->assertSame( 'Ada', $result['first_name'] );
+		$this->assertSame( 'Lovelace', $result['last_name'] );
+	}
+
+	public function test_list_users_hides_pii_without_edit_users() {
+		$target = self::factory()->user->create(
+			array(
+				'role'       => 'author',
+				'user_email' => 'secret@example.test',
+			)
+		);
+
+		// A caller who can list_users but NOT edit_users: an editor with the
+		// one cap added. The directory is visible; email is not.
+		$viewer     = self::factory()->user->create( array( 'role' => 'editor' ) );
+		$viewer_obj = get_user_by( 'id', $viewer );
+		$viewer_obj->add_cap( 'list_users' );
+		wp_set_current_user( $viewer );
+
+		$this->assertTrue( current_user_can( 'list_users' ) );
+		$this->assertFalse( current_user_can( 'edit_users' ), 'Precondition: viewer cannot edit users.' );
+
+		$result = $this->ability( 'saddle/list-users' )->execute( array( 'per_page' => 100 ) );
+		$this->assertIsArray( $result );
+
+		$row = null;
+		foreach ( $result['items'] as $item ) {
+			if ( (int) $item['id'] === (int) $target ) {
+				$row = $item;
+				break;
+			}
+		}
+		$this->assertNotNull( $row, 'The target user must appear in the directory.' );
+		$this->assertArrayHasKey( 'name', $row, 'Public fields are present.' );
+		$this->assertArrayHasKey( 'roles', $row );
+		$this->assertArrayNotHasKey( 'email', $row, 'Email must be hidden from a caller who cannot edit users.' );
+		$this->assertArrayNotHasKey( 'login', $row );
+		$this->assertArrayNotHasKey( 'first_name', $row );
+	}
+
+	/* -------- shaping: get / not found / role filter / pagination -------- */
+
+	public function test_get_user_not_found() {
+		$result = $this->ability( 'saddle/get-user' )->execute( array( 'id' => 999999 ) );
+		$this->assertWPError( $result );
+		$this->assertSame( 'saddle_not_found', $result->get_error_code() );
+	}
+
+	public function test_get_user_rejects_non_positive_id() {
+		// The input schema (id: required, minimum 1) guards this before the
+		// callback, so a zero id is refused as invalid input; the callback's
+		// own saddle_missing_id check is defense-in-depth behind that schema.
+		$result = $this->ability( 'saddle/get-user' )->execute( array( 'id' => 0 ) );
+		$this->assertWPError( $result, 'A non-positive id must be refused.' );
+	}
+
+	public function test_role_filter() {
+		self::factory()->user->create( array( 'role' => 'author' ) );
+		self::factory()->user->create( array( 'role' => 'author' ) );
+
+		$result = $this->ability( 'saddle/list-users' )->execute(
+			array(
+				'role'     => 'author',
+				'per_page' => 100,
+			)
+		);
+
+		$this->assertNotEmpty( $result['items'] );
+		foreach ( $result['items'] as $item ) {
+			$this->assertContains( 'author', $item['roles'], 'The role filter must only return that role.' );
+		}
+	}
+
+	public function test_pagination_envelope() {
+		self::factory()->user->create_many( 5, array( 'role' => 'subscriber' ) );
+		// The admin holds list_users; page through everyone in pages of 2.
+		wp_set_current_user( $this->admin );
+
+		$page1 = $this->ability( 'saddle/list-users' )->execute(
+			array(
+				'per_page' => 2,
+				'page'     => 1,
+			)
+		);
+
+		$this->assertCount( 2, $page1['items'], 'per_page bounds the page size.' );
+		$this->assertSame( 1, $page1['page'] );
+		$this->assertGreaterThanOrEqual( 6, $page1['total'], 'Total counts every user, not just the page.' );
+		$this->assertSame( (int) ceil( $page1['total'] / 2 ), $page1['total_pages'] );
+	}
+}


### PR DESCRIPTION
Closes #13 — the Users read-only surface from the Finalized Plan ([#12](https://github.com/plugpressco/saddle/issues/12), Phase 2 §5).

## What

Two read-tier abilities in the new `includes/abilities/users.php`:

| id | tier | destructive | cap |
|---|---|---|---|
| `saddle/list-users` | `read` | false | `list_users` |
| `saddle/get-user` | `read` | false | `list_users` |

- **No create / update / delete** — user mutation is a higher-risk (privilege-escalation) surface, intentionally left out of scope.
- **Double-gated**: the `list_users` capability (admins only by default) *on top of* the read tier — the user directory is sensitive.
- **PII split**: email, real name, and login are returned only to callers who can `edit_users`; everyone else gets the public profile (name, slug, roles, registered, avatar, post count).
- `list-users` supports role filter, wildcard search, ordering, and pagination (`{items,total,total_pages,page}` envelope).

## Wiring

`saddle.php`: `require` + `wp_abilities_api_init` hook. Free ability count 50 → 52.

## Tests

`tests/users-test.php` (10 tests, 49 assertions) drives the real `wp_get_ability()->execute()` path: subscriber-without-`list_users` denial, PII split, role filter, pagination, not-found.

- Full suite **244 green** (1 pre-existing skip)
- `includes/abilities/users.php` phpcs-clean; no `eval`/`exec`

One manual follow-up remains: a live `list-users`/`get-user` round-trip over MCP on a real site (harness proves the logic; live confirms the transport surface).

🤖 Generated with [Claude Code](https://claude.com/claude-code)