### PR TITLE
chore: reset backlog docs for scope replan

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,7 +63,7 @@ saddle.php                    — bootstrap; wires hooks, defers MCP transport t
 includes/
   class-saddle-tree.php       — builder-agnostic block-tree engine (parse/address/mutate/serialize)
   class-saddle-blocks-*.php   — Gutenberg validation profile, authoring layer, schema/tokens, applied-vs-ignored echo
-  lint/                       — design lint engine (DESIGN-PLAN §2.1): Saddle_Lint runner + Saddle_Lint_Accessor
+  lint/                       — design lint engine: Saddle_Lint runner + Saddle_Lint_Accessor
                                  interface (only builder-specific surface) + 8 rules; Saddle Pro plugs Divi in
   class-saddle-capabilities.php — tier system (read/write/admin), single source of truth for permission_callback
   class-saddle-approval.php   — dry-run + confirm-token gate, single-use, 15-min TTL, target-bound

--- a/STATUS.md
+++ b/STATUS.md
@@ -4,15 +4,14 @@
 **Board:** [PlugPress HQ](https://github.com/orgs/plugpressco/projects/3)
 
 ## Last session
-2026-07-10 — Roadmap replan + shipped Users read-only ([#13](https://github.com/plugpressco/saddle/issues/13)):
-- Scope is being replanned, so the buried Finalized-Plan (#12) items I'd broken out (#14 comments, #15 revision-restore, #16–#19 deferred Phase 3) were **closed as not-planned** — #12 still records the original intent if any needs reviving.
-- Built **#13**: two read-tier user abilities, `saddle/list-users` + `saddle/get-user`, in new `includes/abilities/users.php` (wired in bootstrap require + `wp_abilities_api_init` hook). Both gated on the `list_users` cap (admins only by default) on top of the read tier; PII (email/real name/login) revealed only to callers who can `edit_users`. list-users supports role filter, search, ordering, pagination (`{items,total,total_pages,page}` envelope). No create/update/delete — that surface stays out per the plan. Free ability count 50 → **52**.
-- New `tests/users-test.php` (10 tests, 49 assertions) drives the real `execute()` path: cap-gate denial for a subscriber, PII split, role filter, pagination, not-found. Full suite **244 green**; `includes/abilities/users.php` phpcs-clean; no eval/exec.
+2026-07-10 — Shipped Users read-only ([#13](https://github.com/plugpressco/saddle/issues/13)) + backlog reset for a scope replan:
+- Built + **merged #13** (PR [#20](https://github.com/plugpressco/saddle/pull/20), squashed to `main` as `be79e28`): two read-tier user abilities, `saddle/list-users` + `saddle/get-user`, in new `includes/abilities/users.php` (wired in bootstrap require + `wp_abilities_api_init` hook). Both gated on the `list_users` cap (admins only by default) on top of the read tier; PII (email/real name/login) revealed only to callers who can `edit_users`. list-users supports role filter, search, ordering, pagination (`{items,total,total_pages,page}` envelope). No create/update/delete. Free ability count 50 → **52**. New `tests/users-test.php` (10 tests); full suite **244 green**; phpcs-clean; no eval/exec.
+- **Backlog reset:** closed the session-created spinoffs (#14 comments, #15 revision-restore, #16–#19 deferred Phase 3) AND all roadmap docs (#12 Finalized Plan, #10 Design Quality, #9 Agent Context) as *not planned* — reopenable. Scope is being replanned; the new plan will be filed as fresh issues after discussion. Local plan `.md` files were already migrated + deleted 2026-07-07.
 
 ## Next up
-- **Not committed/pushed** — the #13 work is in the working tree only. Commit + tag when ready.
-- Live round-trip on a real site is the one remaining manual check for #13 (harness proves logic; a live `list-users`/`get-user` call over MCP confirms the transport surface).
-- Scope replan: decide the new Saddle direction before reopening any of the closed backlog (#14–#19).
+- **Scope replan** — define the new Saddle direction, then file it as fresh GitHub issues. Nothing in the old backlog restarts until then.
+- CI: the PHPUnit job has never passed on GitHub Actions (no WP core set up in the runner — bootstrap looks for a local ABSPATH). Worth fixing as its own PR so future PRs get a real green.
+- #13 live round-trip on a real site is the one remaining manual check (harness proves logic; a live `list-users`/`get-user` call over MCP confirms the transport surface).
 
 ## Blockers / open questions
 - Saddle scope under active replanning — hold new feature work until the new plan lands.


### PR DESCRIPTION
Docs-only cleanup after the backlog reset.

- The old roadmap/plan `.md` files were already migrated to issues + deleted (2026-07-07). The roadmap issues (#12, #10, #9) are now closed pending a scope replan.
- **CLAUDE.md**: dropped the dangling `DESIGN-PLAN §2.1` citation (file no longer exists) from the architecture map.
- **STATUS.md**: recorded the #13 merge (PR #20) + the backlog reset; "Next up" now says hold feature work until the new scope is defined and filed as fresh issues.

No code changed (PHPCS unaffected; the PHPUnit job's pre-existing red is the runner-has-no-WP-core issue, unrelated to this).

🤖 Generated with [Claude Code](https://claude.com/claude-code)