### PR TITLE
F1: Saddle_Lint_Style_Accessor companion interface + Gutenberg impl

### DIFF
--- a/includes/lint/class-saddle-lint-gutenberg-accessor.php
+++ b/includes/lint/class-saddle-lint-gutenberg-accessor.php
@@ -13,7 +13,7 @@ defined( 'ABSPATH' ) || exit;
  * rules compare real colors; raw values in the style object are returned
  * as-is. Facts that don't exist on a block type return null and rules skip.
  */
-class Saddle_Lint_Gutenberg_Accessor implements Saddle_Lint_Accessor {
+class Saddle_Lint_Gutenberg_Accessor implements Saddle_Lint_Accessor, Saddle_Lint_Style_Accessor {
 
 	/**
 	 * theme.json color slug → value map, built once per instance.
@@ -21,6 +21,13 @@ class Saddle_Lint_Gutenberg_Accessor implements Saddle_Lint_Accessor {
 	 * @var array<string,string>|null
 	 */
 	private $palette = null;
+
+	/**
+	 * theme.json font-size slug → value map, built once per instance.
+	 *
+	 * @var array<string,string>|null
+	 */
+	private $font_sizes = null;
 
 	/**
 	 * The node's background: style.color.background, or the resolved
@@ -132,6 +139,182 @@ class Saddle_Lint_Gutenberg_Accessor implements Saddle_Lint_Accessor {
 
 	/*
 	---------------------------------------------------------------------
+	 * Saddle_Lint_Style_Accessor (companion facts)
+	 * -------------------------------------------------------------------
+	 */
+
+	/**
+	 * style.border.radius: a plain string, or per-corner values serialized
+	 * clockwise from top-left so identical corner sets compare equal.
+	 *
+	 * @param array $node Raw block array.
+	 * @return string|null
+	 */
+	public function border_radius( array $node ) {
+		$attrs  = $this->attrs( $node );
+		$radius = isset( $attrs['style']['border']['radius'] ) ? $attrs['style']['border']['radius'] : null;
+
+		if ( is_string( $radius ) && '' !== trim( $radius ) ) {
+			return trim( $radius );
+		}
+		if ( is_array( $radius ) && $radius ) {
+			$corners = array();
+			foreach ( array( 'topLeft', 'topRight', 'bottomRight', 'bottomLeft' ) as $corner ) {
+				$corners[] = isset( $radius[ $corner ] ) && is_string( $radius[ $corner ] ) ? trim( $radius[ $corner ] ) : '0';
+			}
+			return implode( ' ', $corners );
+		}
+		return null;
+	}
+
+	/**
+	 * style.spacing.blockGap: a plain string, or "row col" when the two axes
+	 * differ (blockGap objects carry top = row gap, left = column gap).
+	 *
+	 * @param array $node Raw block array.
+	 * @return string|null
+	 */
+	public function gap( array $node ) {
+		$attrs = $this->attrs( $node );
+		$gap   = isset( $attrs['style']['spacing']['blockGap'] ) ? $attrs['style']['spacing']['blockGap'] : null;
+
+		if ( is_string( $gap ) && '' !== trim( $gap ) ) {
+			return trim( $gap );
+		}
+		if ( is_array( $gap ) && $gap ) {
+			$row = isset( $gap['top'] ) && is_string( $gap['top'] ) ? trim( $gap['top'] ) : '';
+			$col = isset( $gap['left'] ) && is_string( $gap['left'] ) ? trim( $gap['left'] ) : '';
+			if ( '' === $row && '' === $col ) {
+				return null;
+			}
+			if ( '' === $row || '' === $col || $row === $col ) {
+				return '' !== $row ? $row : $col;
+			}
+			return $row . ' ' . $col;
+		}
+		return null;
+	}
+
+	/**
+	 * style.typography.fontSize raw, or the fontSize preset slug resolved to
+	 * its theme.json value. Unknown slugs paint nothing → null.
+	 *
+	 * @param array $node Raw block array.
+	 * @return string|null
+	 */
+	public function font_size( array $node ) {
+		$attrs = $this->attrs( $node );
+
+		if ( isset( $attrs['style']['typography']['fontSize'] ) && is_string( $attrs['style']['typography']['fontSize'] ) ) {
+			return $attrs['style']['typography']['fontSize'];
+		}
+		if ( ! empty( $attrs['fontSize'] ) && is_string( $attrs['fontSize'] ) ) {
+			return $this->resolve_font_size_slug( $attrs['fontSize'] );
+		}
+		return null;
+	}
+
+	/**
+	 * core/image is the content image; its alt lives on the <img> tag in the
+	 * saved markup, not in attrs. Covers and other background media are
+	 * decorative by convention → null (never nag about them).
+	 *
+	 * @param array $node Raw block array.
+	 * @return string|null
+	 */
+	public function image_alt( array $node ) {
+		if ( 'core/image' !== (string) $node['blockName'] ) {
+			return null;
+		}
+		$html = (string) $node['innerHTML'];
+		if ( false === stripos( $html, '<img' ) ) {
+			// An image block with no image yet — nothing rendered to judge.
+			return null;
+		}
+		if ( preg_match( '/<img[^>]*\salt=("|\')(.*?)\1/is', $html, $m ) ) {
+			return trim( html_entity_decode( $m[2], ENT_QUOTES ) );
+		}
+		return '';
+	}
+
+	/**
+	 * core/heading's level; the attr is only serialized when it differs from
+	 * the default h2.
+	 *
+	 * @param array $node Raw block array.
+	 * @return int|null
+	 */
+	public function heading_level( array $node ) {
+		if ( 'core/heading' !== (string) $node['blockName'] ) {
+			return null;
+		}
+		$attrs = $this->attrs( $node );
+		$level = isset( $attrs['level'] ) ? (int) $attrs['level'] : 2;
+		return ( $level >= 1 && $level <= 6 ) ? $level : 2;
+	}
+
+	/**
+	 * Gutenberg has no user-editable global preset entity (registered block
+	 * styles are code, not content) — nothing to couple to.
+	 *
+	 * @param array $node Raw block array.
+	 * @return null
+	 */
+	public function global_preset_ref( array $node ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found -- Fixed accessor signature.
+		return null;
+	}
+
+	/**
+	 * Every var(--…) reference in the node's own attrs, plus Gutenberg's
+	 * internal var:preset|group|slug form normalized to its CSS custom
+	 * property name.
+	 *
+	 * @param array $node Raw block array.
+	 * @return string[]
+	 */
+	public function variable_refs( array $node ) {
+		$attrs = $this->attrs( $node );
+		if ( ! $attrs ) {
+			return array();
+		}
+		$blob = (string) wp_json_encode( $attrs );
+
+		$refs = array();
+		if ( preg_match_all( '/var\((--[a-z0-9_\-]+)/i', $blob, $m ) ) {
+			$refs = $m[1];
+		}
+		// Internal preset syntax: "var:preset|color|primary".
+		if ( preg_match_all( '/var:preset\|([a-z0-9_\-]+)\|([a-z0-9_\-]+)/i', $blob, $m, PREG_SET_ORDER ) ) {
+			foreach ( $m as $hit ) {
+				$refs[] = '--wp--preset--' . $hit[1] . '--' . $hit[2];
+			}
+		}
+		return array_values( array_unique( $refs ) );
+	}
+
+	/**
+	 * Free Gutenberg pages have no committed brief store — the brief is the
+	 * builder driver's concern. Returning null keeps the conformance rule
+	 * silent here (briefless pages get zero brief violations).
+	 *
+	 * @return null
+	 */
+	public function design_brief() {
+		return null;
+	}
+
+	/**
+	 * Tree-only accessor: the render pillar fills this seam later.
+	 *
+	 * @param array $node Raw block array.
+	 * @return null
+	 */
+	public function computed_style( array $node ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found -- Fixed accessor signature.
+		return null;
+	}
+
+	/*
+	---------------------------------------------------------------------
 	 * Internals
 	 * -------------------------------------------------------------------
 	 */
@@ -181,5 +364,41 @@ class Saddle_Lint_Gutenberg_Accessor implements Saddle_Lint_Accessor {
 			}
 		}
 		return isset( $this->palette[ $slug ] ) ? $this->palette[ $slug ] : null;
+	}
+
+	/**
+	 * Resolve a font-size preset slug to its theme.json value. Unknown slugs
+	 * return null — same contract as resolve_palette_slug().
+	 *
+	 * @param string $slug Preset slug.
+	 * @return string|null
+	 */
+	private function resolve_font_size_slug( $slug ) {
+		if ( null === $this->font_sizes ) {
+			$this->font_sizes = array();
+			if ( class_exists( 'WP_Theme_JSON_Resolver' ) ) {
+				$settings = WP_Theme_JSON_Resolver::get_merged_data()->get_settings();
+				$sizes    = isset( $settings['typography']['fontSizes'] ) ? (array) $settings['typography']['fontSizes'] : array();
+				// Origin-keyed or flat; theme entries are the site's scale and win.
+				if ( isset( $sizes[0] ) ) {
+					$groups = array( $sizes );
+				} else {
+					$groups = array();
+					foreach ( array( 'theme', 'custom', 'default' ) as $origin ) {
+						if ( isset( $sizes[ $origin ] ) && is_array( $sizes[ $origin ] ) ) {
+							$groups[] = $sizes[ $origin ];
+						}
+					}
+				}
+				foreach ( $groups as $group ) {
+					foreach ( $group as $preset ) {
+						if ( is_array( $preset ) && isset( $preset['slug'], $preset['size'] ) && ! isset( $this->font_sizes[ $preset['slug'] ] ) ) {
+							$this->font_sizes[ (string) $preset['slug'] ] = (string) $preset['size'];
+						}
+					}
+				}
+			}
+		}
+		return isset( $this->font_sizes[ $slug ] ) ? $this->font_sizes[ $slug ] : null;
 	}
 }

--- a/includes/lint/interface-saddle-lint-style-accessor.php
+++ b/includes/lint/interface-saddle-lint-style-accessor.php
@@ -1,0 +1,125 @@
+<?php
+/**
+ * The additive companion to Saddle_Lint_Accessor.
+ *
+ * @package Saddle
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Extended design facts for the deeper quality rules (closed-loop scope,
+ * https://github.com/plugpressco/saddle/issues/23).
+ *
+ * A SEPARATE interface, on purpose: adding methods to Saddle_Lint_Accessor
+ * would fatal any older accessor implementation the moment free Saddle
+ * updates. Instead, accessors additionally implement this companion, and
+ * rules feature-detect with `$accessor instanceof Saddle_Lint_Style_Accessor`
+ * — an accessor that hasn't caught up simply makes those rules skip.
+ *
+ * The base interface's contract carries over unchanged: methods take a raw
+ * block array from Saddle_Tree::parse(), accessors resolve indirection where
+ * they can (preset slug → theme.json value, var(--gcid-…) → global palette),
+ * and every fact that is unknown or not applicable returns null — rules must
+ * skip, never guess.
+ */
+interface Saddle_Lint_Style_Accessor {
+
+	/**
+	 * The node's own corner radius.
+	 *
+	 * Composite per-corner values are serialized deterministically (clockwise
+	 * from top-left, space-joined) so two nodes with identical corners compare
+	 * equal — the monotony rules only ever test identity, never parse.
+	 *
+	 * @param array $node Raw block array.
+	 * @return string|null CSS radius string, or null when the node sets none.
+	 */
+	public function border_radius( array $node );
+
+	/**
+	 * The node's own gap between children (row/column gap).
+	 *
+	 * @param array $node Raw block array.
+	 * @return string|null CSS gap string ("row col" when they differ), or null
+	 *                     when the node sets none / has no layout gap.
+	 */
+	public function gap( array $node );
+
+	/**
+	 * The node's own font size, resolved as far as possible.
+	 *
+	 * @param array $node Raw block array.
+	 * @return string|null CSS size (preset slugs resolved to their value), or
+	 *                     null when unset/unresolvable.
+	 */
+	public function font_size( array $node );
+
+	/**
+	 * The alt text of an image-content node.
+	 *
+	 * Only content images count — decorative background media (covers,
+	 * section backgrounds) returns null, so the missing-alt rule never nags
+	 * about media that is correctly decorative. Alt bound to dynamic content
+	 * counts as satisfied and returns a non-empty sentinel.
+	 *
+	 * @param array $node Raw block array.
+	 * @return string|null null when the node is not a content image;
+	 *                     '' when it is one and the alt is missing/empty
+	 *                     (that IS the lint); the alt text otherwise.
+	 */
+	public function image_alt( array $node );
+
+	/**
+	 * The heading level of a heading node.
+	 *
+	 * @param array $node Raw block array.
+	 * @return int|null 1–6, or null when the node is not a heading.
+	 */
+	public function heading_level( array $node );
+
+	/**
+	 * The id of the user-editable global preset this node is bound to.
+	 *
+	 * "Global preset" means a site-wide, owner-editable style entity (Divi's
+	 * global presets); registered code-level block styles do not count.
+	 *
+	 * @param array $node Raw block array.
+	 * @return string|null Preset id, or null when unbound / no such concept.
+	 */
+	public function global_preset_ref( array $node );
+
+	/**
+	 * The design-token variables this node's own attrs reference.
+	 *
+	 * @param array $node Raw block array.
+	 * @return string[] Unique variable names (e.g. '--wp--preset--color--primary',
+	 *                  '--gcid-abc123'), document-order first occurrence.
+	 *                  Empty array when none.
+	 */
+	public function variable_refs( array $node );
+
+	/**
+	 * The page's committed design brief merged over derived site constraints.
+	 *
+	 * Shape (all keys optional): { palette: string[], accent_count: int,
+	 * radius_scale: string[], spacing_scale: string[], type_scale: string[],
+	 * layout_concept: string, palette_closed: bool }. The brief-conformance
+	 * rule fires ONLY when this returns non-null — briefless pages get zero
+	 * brief violations.
+	 *
+	 * @return array|null The brief, or null when none is committed/derivable.
+	 */
+	public function design_brief();
+
+	/**
+	 * Render-backed computed style for a node, when a render pillar can
+	 * supply one (box model, resolved colors as painted). The seam the
+	 * render engine fills; tree-only accessors return null and rules fall
+	 * back to persisted-attr facts.
+	 *
+	 * @param array $node Raw block array.
+	 * @return array|null Computed style map, or null when unavailable.
+	 */
+	public function computed_style( array $node );
+}

--- a/saddle.php
+++ b/saddle.php
@@ -36,6 +36,7 @@ require_once SADDLE_DIR . 'includes/class-saddle-blocks-author.php';
 require_once SADDLE_DIR . 'includes/class-saddle-blocks-schema.php';
 require_once SADDLE_DIR . 'includes/class-saddle-blocks-echo.php';
 require_once SADDLE_DIR . 'includes/lint/interface-saddle-lint-accessor.php';
+require_once SADDLE_DIR . 'includes/lint/interface-saddle-lint-style-accessor.php';
 require_once SADDLE_DIR . 'includes/lint/class-saddle-lint.php';
 require_once SADDLE_DIR . 'includes/lint/class-saddle-lint-rule.php';
 require_once SADDLE_DIR . 'includes/lint/class-saddle-lint-color.php';

--- a/tests/style-accessor-test.php
+++ b/tests/style-accessor-test.php
@@ -1,0 +1,260 @@
+<?php
+/**
+ * The Saddle_Lint_Style_Accessor companion interface + Gutenberg impl.
+ *
+ * Pins the closed-loop foundation (https://github.com/plugpressco/saddle/issues/23):
+ * every companion getter both ways — the populated case resolves and the
+ * unknown/not-applicable case returns null (rules skip, never guess) — plus
+ * the versioning guarantee the companion design exists for: an accessor that
+ * implements ONLY the base interface still runs through the engine with zero
+ * fatals.
+ *
+ * @package Saddle
+ */
+
+class Saddle_Style_Accessor_Test extends WP_UnitTestCase {
+
+	/**
+	 * The accessor under test.
+	 *
+	 * @var Saddle_Lint_Gutenberg_Accessor
+	 */
+	private $accessor;
+
+	public function set_up() {
+		parent::set_up();
+		$this->accessor = new Saddle_Lint_Gutenberg_Accessor();
+	}
+
+	/* -------- helpers -------- */
+
+	private function node( $markup ) {
+		$nodes = Saddle_Lint::nodes( Saddle_Tree::parse( $markup ) );
+		$this->assertNotEmpty( $nodes, 'Fixture markup must parse to at least one node.' );
+		return $nodes[0]['block'];
+	}
+
+	private function group_node( array $attrs ) {
+		$json = $attrs ? ' ' . wp_json_encode( $attrs ) : '';
+		return $this->node( '<!-- wp:group' . $json . ' --><div class="wp-block-group"></div><!-- /wp:group -->' );
+	}
+
+	/* -------- the companion contract -------- */
+
+	public function test_gutenberg_accessor_implements_both_interfaces() {
+		$this->assertInstanceOf( 'Saddle_Lint_Accessor', $this->accessor );
+		$this->assertInstanceOf( 'Saddle_Lint_Style_Accessor', $this->accessor );
+	}
+
+	public function test_engine_runs_with_a_base_only_accessor_without_fatal() {
+		// The whole point of the companion split: an accessor that has not
+		// caught up (an older Pro) must keep working against a newer engine.
+		$legacy = new Saddle_Test_Legacy_Accessor();
+		$this->assertNotInstanceOf( 'Saddle_Lint_Style_Accessor', $legacy );
+
+		$tree       = Saddle_Tree::parse( '<!-- wp:heading --><h2 class="wp-block-heading">Hi</h2><!-- /wp:heading -->' );
+		$violations = Saddle_Lint::run( $tree, $legacy );
+		$this->assertIsArray( $violations, 'A base-only accessor must run clean through the engine.' );
+	}
+
+	/* -------- border_radius -------- */
+
+	public function test_border_radius_string_form() {
+		$node = $this->group_node( array( 'style' => array( 'border' => array( 'radius' => '8px' ) ) ) );
+		$this->assertSame( '8px', $this->accessor->border_radius( $node ) );
+	}
+
+	public function test_border_radius_corner_form_serializes_clockwise() {
+		$node = $this->group_node(
+			array(
+				'style' => array(
+					'border' => array(
+						'radius' => array(
+							'topLeft'     => '8px',
+							'topRight'    => '8px',
+							'bottomRight' => '0px',
+							'bottomLeft'  => '0px',
+						),
+					),
+				),
+			)
+		);
+		$this->assertSame( '8px 8px 0px 0px', $this->accessor->border_radius( $node ) );
+	}
+
+	public function test_border_radius_null_when_unset() {
+		$this->assertNull( $this->accessor->border_radius( $this->group_node( array() ) ) );
+	}
+
+	/* -------- gap -------- */
+
+	public function test_gap_string_form() {
+		$node = $this->group_node( array( 'style' => array( 'spacing' => array( 'blockGap' => '24px' ) ) ) );
+		$this->assertSame( '24px', $this->accessor->gap( $node ) );
+	}
+
+	public function test_gap_axis_form_joins_when_different_collapses_when_equal() {
+		$differs = $this->group_node(
+			array(
+				'style' => array(
+					'spacing' => array(
+						'blockGap' => array(
+							'top'  => '16px',
+							'left' => '32px',
+						),
+					),
+				),
+			)
+		);
+		$this->assertSame( '16px 32px', $this->accessor->gap( $differs ) );
+
+		$same = $this->group_node(
+			array(
+				'style' => array(
+					'spacing' => array(
+						'blockGap' => array(
+							'top'  => '16px',
+							'left' => '16px',
+						),
+					),
+				),
+			)
+		);
+		$this->assertSame( '16px', $this->accessor->gap( $same ) );
+	}
+
+	public function test_gap_null_when_unset() {
+		$this->assertNull( $this->accessor->gap( $this->group_node( array() ) ) );
+	}
+
+	/* -------- font_size -------- */
+
+	public function test_font_size_raw_value() {
+		$node = $this->node( '<!-- wp:paragraph {"style":{"typography":{"fontSize":"18px"}}} --><p>x</p><!-- /wp:paragraph -->' );
+		$this->assertSame( '18px', $this->accessor->font_size( $node ) );
+	}
+
+	public function test_font_size_preset_slug_resolves_and_unknown_is_null() {
+		// "large" ships in core's default theme.json scale, on every install.
+		$known = $this->node( '<!-- wp:paragraph {"fontSize":"large"} --><p>x</p><!-- /wp:paragraph -->' );
+		$size  = $this->accessor->font_size( $known );
+		$this->assertIsString( $size );
+		$this->assertNotSame( '', $size );
+
+		$unknown = $this->node( '<!-- wp:paragraph {"fontSize":"no-such-size"} --><p>x</p><!-- /wp:paragraph -->' );
+		$this->assertNull( $this->accessor->font_size( $unknown ) );
+	}
+
+	public function test_font_size_null_when_unset() {
+		$node = $this->node( '<!-- wp:paragraph --><p>x</p><!-- /wp:paragraph -->' );
+		$this->assertNull( $this->accessor->font_size( $node ) );
+	}
+
+	/* -------- image_alt -------- */
+
+	public function test_image_alt_returns_text_when_present() {
+		$node = $this->node( '<!-- wp:image {"id":5} --><figure class="wp-block-image"><img src="x.jpg" alt="A brown dog"/></figure><!-- /wp:image -->' );
+		$this->assertSame( 'A brown dog', $this->accessor->image_alt( $node ) );
+	}
+
+	public function test_image_alt_empty_string_when_missing_or_blank() {
+		$missing = $this->node( '<!-- wp:image {"id":5} --><figure class="wp-block-image"><img src="x.jpg"/></figure><!-- /wp:image -->' );
+		$this->assertSame( '', $this->accessor->image_alt( $missing ) );
+
+		$blank = $this->node( '<!-- wp:image {"id":5} --><figure class="wp-block-image"><img src="x.jpg" alt=""/></figure><!-- /wp:image -->' );
+		$this->assertSame( '', $this->accessor->image_alt( $blank ) );
+	}
+
+	public function test_image_alt_null_for_non_images_and_empty_image_blocks() {
+		$paragraph = $this->node( '<!-- wp:paragraph --><p>x</p><!-- /wp:paragraph -->' );
+		$this->assertNull( $this->accessor->image_alt( $paragraph ) );
+
+		// Covers are background media — decorative by convention, never nagged.
+		$cover = $this->node( '<!-- wp:cover {"url":"x.jpg"} --><div class="wp-block-cover"><img class="wp-block-cover__image-background" src="x.jpg"/></div><!-- /wp:cover -->' );
+		$this->assertNull( $this->accessor->image_alt( $cover ) );
+
+		// An image block with no image selected yet has nothing to judge.
+		$placeholder = $this->node( '<!-- wp:image --><figure class="wp-block-image"></figure><!-- /wp:image -->' );
+		$this->assertNull( $this->accessor->image_alt( $placeholder ) );
+	}
+
+	/* -------- heading_level -------- */
+
+	public function test_heading_level_default_and_explicit() {
+		$h2 = $this->node( '<!-- wp:heading --><h2 class="wp-block-heading">x</h2><!-- /wp:heading -->' );
+		$this->assertSame( 2, $this->accessor->heading_level( $h2 ) );
+
+		$h4 = $this->node( '<!-- wp:heading {"level":4} --><h4 class="wp-block-heading">x</h4><!-- /wp:heading -->' );
+		$this->assertSame( 4, $this->accessor->heading_level( $h4 ) );
+	}
+
+	public function test_heading_level_null_for_non_headings() {
+		$node = $this->node( '<!-- wp:paragraph --><p>x</p><!-- /wp:paragraph -->' );
+		$this->assertNull( $this->accessor->heading_level( $node ) );
+	}
+
+	/* -------- variable_refs -------- */
+
+	public function test_variable_refs_finds_css_vars_and_internal_preset_form() {
+		$node = $this->group_node(
+			array(
+				'style' => array(
+					'color'   => array( 'background' => 'var(--wp--preset--color--primary)' ),
+					'spacing' => array( 'padding' => array( 'top' => 'var:preset|spacing|50' ) ),
+				),
+			)
+		);
+		$refs = $this->accessor->variable_refs( $node );
+		$this->assertContains( '--wp--preset--color--primary', $refs );
+		$this->assertContains( '--wp--preset--spacing--50', $refs );
+	}
+
+	public function test_variable_refs_empty_when_none() {
+		$this->assertSame( array(), $this->accessor->variable_refs( $this->group_node( array() ) ) );
+	}
+
+	/* -------- the free nulls: preset ref, brief, computed style -------- */
+
+	public function test_free_accessor_null_facts() {
+		$node = $this->group_node( array() );
+		$this->assertNull( $this->accessor->global_preset_ref( $node ), 'Gutenberg has no user-editable global preset entity.' );
+		$this->assertNull( $this->accessor->design_brief(), 'Free pages have no committed brief store.' );
+		$this->assertNull( $this->accessor->computed_style( $node ), 'Tree-only accessor: render fills this seam later.' );
+	}
+}
+
+/**
+ * A base-only accessor, as an older Pro build would ship: implements
+ * Saddle_Lint_Accessor but NOT the companion. Used to prove the engine keeps
+ * running against it.
+ */
+class Saddle_Test_Legacy_Accessor implements Saddle_Lint_Accessor {
+
+	public function background_color( array $node ) {
+		return null;
+	}
+
+	public function text_color( array $node ) {
+		return null;
+	}
+
+	public function is_button( array $node ) {
+		return false;
+	}
+
+	public function button_is_filled( array $node ) {
+		return true;
+	}
+
+	public function alignment( array $node ) {
+		return null;
+	}
+
+	public function padding( array $node ) {
+		return null;
+	}
+
+	public function title_text( array $node ) {
+		return null;
+	}
+}


### PR DESCRIPTION
Closes #23 — the closed-loop foundation ([epic #22](https://github.com/plugpressco/saddle/issues/22), build step F1). Unblocks F2/F4/F5 and Pro P1/P2.

## What

The deeper quality rules need design facts the base lint accessor doesn't expose. Adding methods to `Saddle_Lint_Accessor` would fatal older Pro accessors against a newer free, so the new facts live on an **additive companion interface** — rules feature-detect with `instanceof` and skip silently when an accessor hasn't caught up.

- **`interface-saddle-lint-style-accessor.php`**: `border_radius`, `gap`, `font_size`, `image_alt`, `heading_level`, `global_preset_ref`, `variable_refs`, `design_brief`, + the `computed_style` seam the render pillar fills later. Base contract carries over: resolve what you can, **null over guessing**.
- **Gutenberg accessor implements it**: corner radii serialized clockwise (identity-comparable), blockGap axes joined, font-size slugs resolved via theme.json (mirrors the palette resolver), `core/image` alt read off the saved `<img>` (covers stay decorative → null), `var(--…)` + internal `var:preset|…` refs normalized.

## Tests

`tests/style-accessor-test.php` — 19 tests: every getter both ways (populated + null), plus the versioning guarantee the split exists for: a **base-only legacy accessor runs through `Saddle_Lint::run()` with zero fatals**.

Full suite **263 green** (+19); phpcs clean. (CI PHPUnit red is the pre-existing no-WP-core runner issue.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)