### PR TITLE
F2: Agent Eyes — render engine + saddle/render-node

### DIFF
--- a/includes/abilities/render.php
+++ b/includes/abilities/render.php
@@ -1,0 +1,163 @@
+<?php
+/**
+ * The render abilities — the agent's eyes.
+ *
+ * saddle/render-node shows an agent the EFFECTIVE result of what it built:
+ * persisted attrs resolved through presets/globals into a normalized style
+ * map, plus rendered HTML. Native pages use the Gutenberg accessor; builder
+ * pages resolve theirs through the `saddle_render_accessor` filter — the
+ * same one-tool-surface pattern as lint (closed-loop scope,
+ * https://github.com/plugpressco/saddle/issues/24).
+ *
+ * @package Saddle
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Register the render abilities. Hooked to `wp_abilities_api_init`.
+ */
+function saddle_register_render_abilities() {
+
+	wp_register_ability(
+		'saddle/render-node',
+		array(
+			'label'               => __( 'Render a node', 'saddle' ),
+			'description'         => __( 'Shows what a page node actually looks like from its SAVED state: effective styles (colors, padding, font size, radius — presets and global tokens resolved to real values) and its rendered HTML. Read-only. Call with an "address" from get-blocks/divi-get-page to inspect one node after building or editing it; call without an address for a whole-page section outline (address, type, first text, key styles per section) and then drill into sections by address. Use it as your eyes: build, render, judge, fix.', 'saddle' ),
+			'category'            => 'saddle',
+			'input_schema'        => array(
+				'type'       => 'object',
+				'required'   => array( 'post_id' ),
+				'properties' => array(
+					'post_id' => array(
+						'type'        => 'integer',
+						'description' => __( 'The post or page to look at.', 'saddle' ),
+					),
+					'address' => array(
+						'type'        => 'string',
+						'description' => __( 'Dot address of one node (e.g. "0.1.0"). Omit for the whole-page outline.', 'saddle' ),
+					),
+					'include' => array(
+						'type'        => 'array',
+						'items'       => array(
+							'type' => 'string',
+							'enum' => array( 'styles', 'html' ),
+						),
+						'description' => __( 'Artifacts to include for a node (default: both).', 'saddle' ),
+					),
+				),
+			),
+			'execute_callback'    => array( 'Saddle_Render_Abilities', 'render_node' ),
+			'permission_callback' => Saddle_Capabilities::permission( 'read', 'read', 'render-node' ),
+			'meta'                => saddle_ability_meta( true, false, true, 'read' ),
+		)
+	);
+}
+
+/**
+ * Execute callbacks for the render abilities.
+ */
+class Saddle_Render_Abilities {
+
+	/**
+	 * saddle/render-node.
+	 *
+	 * @param array $input Ability input.
+	 * @return array|WP_Error
+	 */
+	public static function render_node( $input = null ) {
+		$input = is_array( $input ) ? $input : array();
+		$post  = get_post( isset( $input['post_id'] ) ? (int) $input['post_id'] : 0 );
+		if ( ! $post || ! in_array( $post->post_type, array( 'post', 'page' ), true ) ) {
+			return new WP_Error( 'saddle_not_found', __( 'No post or page with that ID.', 'saddle' ), array( 'status' => 404 ) );
+		}
+		if ( ! current_user_can( 'read_post', $post->ID ) ) {
+			return new WP_Error( 'saddle_forbidden', __( 'You cannot read this post.', 'saddle' ), array( 'status' => 403 ) );
+		}
+
+		$accessor = self::accessor_for( $post );
+		if ( is_wp_error( $accessor ) ) {
+			return $accessor;
+		}
+
+		$tree    = Saddle_Tree::parse( $post->post_content );
+		$builder = Saddle_Abilities::builder_signature( $post );
+		$address = isset( $input['address'] ) ? trim( (string) $input['address'] ) : '';
+
+		if ( '' === $address ) {
+			$outline = Saddle_Render::outline( $tree, $accessor );
+			return array(
+				'id'      => $post->ID,
+				'builder' => null === $builder ? 'native' : $builder,
+				'outline' => $outline,
+				'count'   => count( $outline ),
+				'note'    => __( 'Top-level sections only. Drill into one with the same call plus its "address". Styles shown are the persisted effective values, not a browser render.', 'saddle' ),
+			);
+		}
+
+		$include = self::include_list( $input );
+		$view    = Saddle_Render::node( $post, $tree, $address, $accessor, $include );
+		if ( is_wp_error( $view ) ) {
+			return $view;
+		}
+
+		return array_merge(
+			array( 'id' => $post->ID ),
+			$view,
+			array(
+				'note' => __( 'Effective persisted styles with presets/tokens resolved — what the saved state means, not a browser screenshot.', 'saddle' ),
+			)
+		);
+	}
+
+	/**
+	 * Resolve the render accessor for a post: Gutenberg for native pages,
+	 * the `saddle_render_accessor` filter for builder pages.
+	 *
+	 * @param WP_Post $post The post.
+	 * @return Saddle_Render_Accessor|WP_Error
+	 */
+	private static function accessor_for( WP_Post $post ) {
+		$builder  = Saddle_Abilities::builder_signature( $post );
+		$accessor = null === $builder ? new Saddle_Render_Gutenberg_Accessor() : null;
+
+		/**
+		 * Filter the render accessor for a page.
+		 *
+		 * Builder integrations (Saddle Pro's Divi driver, Elementor/Bricks
+		 * later) return their Saddle_Render_Accessor implementation when
+		 * they own $builder. Null means the page cannot be rendered here.
+		 *
+		 * @param Saddle_Render_Accessor|null $accessor Accessor (Gutenberg's for native pages).
+		 * @param string|null                 $builder  Detected builder, null = native.
+		 * @param WP_Post                     $post     The post.
+		 */
+		$accessor = apply_filters( 'saddle_render_accessor', $accessor, $builder, $post );
+
+		if ( ! $accessor instanceof Saddle_Render_Accessor ) {
+			return new WP_Error(
+				'saddle_render_unsupported',
+				sprintf(
+					/* translators: 1: post ID, 2: builder name. */
+					__( 'Post #%1$d is built with %2$s, and no render accessor for that builder is installed. Divi 5 pages need Saddle Pro.', 'saddle' ),
+					$post->ID,
+					(string) $builder
+				),
+				array( 'status' => 409 )
+			);
+		}
+		return $accessor;
+	}
+
+	/**
+	 * The validated include list, defaulting to both artifacts.
+	 *
+	 * @param array $input Ability input.
+	 * @return string[]
+	 */
+	private static function include_list( array $input ) {
+		$include = isset( $input['include'] ) && is_array( $input['include'] ) ? $input['include'] : array();
+		$include = array_values( array_intersect( array( 'styles', 'html' ), array_map( 'strval', $include ) ) );
+		return $include ? $include : array( 'styles', 'html' );
+	}
+}

--- a/includes/render/class-saddle-render-gutenberg-accessor.php
+++ b/includes/render/class-saddle-render-gutenberg-accessor.php
@@ -1,0 +1,85 @@
+<?php
+/**
+ * The Gutenberg implementation of the render accessor.
+ *
+ * @package Saddle
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Native blocks render in-process through core's own pipeline, and effective
+ * styles come from the SAME resolution the lint accessor already does —
+ * composition, not a second resolver, so lint and render can never disagree
+ * about what a preset slug means.
+ */
+class Saddle_Render_Gutenberg_Accessor implements Saddle_Render_Accessor {
+
+	/**
+	 * The lint accessor doing the actual attr resolution.
+	 *
+	 * @var Saddle_Lint_Gutenberg_Accessor
+	 */
+	private $facts;
+
+	public function __construct() {
+		$this->facts = new Saddle_Lint_Gutenberg_Accessor();
+	}
+
+	/**
+	 * Effective styles assembled from the lint accessor's resolved facts.
+	 * Keys the node doesn't style are omitted — an empty map means "this
+	 * node inherits everything".
+	 *
+	 * @param array $node Raw block array.
+	 * @return array
+	 */
+	public function effective_styles( array $node ) {
+		$styles = array(
+			'background'   => $this->facts->background_color( $node ),
+			'color'        => $this->facts->text_color( $node ),
+			'padding'      => $this->facts->padding( $node ),
+			'textAlign'    => $this->facts->alignment( $node ),
+			'fontSize'     => $this->facts->font_size( $node ),
+			'borderRadius' => $this->facts->border_radius( $node ),
+			'gap'          => $this->facts->gap( $node ),
+		);
+		$styles = array_filter(
+			$styles,
+			static function ( $value ) {
+				return null !== $value;
+			}
+		);
+
+		if ( $this->facts->is_button( $node ) ) {
+			$styles['button_filled'] = $this->facts->button_is_filled( $node );
+		}
+		return $styles;
+	}
+
+	/**
+	 * Render the node through core's own block renderer. In-process: block
+	 * markup and dynamic blocks are real, theme stylesheets are not applied.
+	 *
+	 * @param WP_Post $post    The post.
+	 * @param array   $tree    Parsed tree.
+	 * @param string  $address Dot address.
+	 * @return string|WP_Error
+	 */
+	public function render_node_html( WP_Post $post, array $tree, $address ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundBeforeLastUsed -- Fixed accessor signature.
+		$block = Saddle_Tree::get( $tree, (string) $address );
+		if ( ! $block ) {
+			return new WP_Error( 'saddle_render_no_node', __( 'No node at that address.', 'saddle' ) );
+		}
+		return render_block( $block );
+	}
+
+	/**
+	 * In-process: rendered inside this request, theme CSS not applied.
+	 *
+	 * @return string
+	 */
+	public function render_fidelity() {
+		return 'in-process';
+	}
+}

--- a/includes/render/class-saddle-render.php
+++ b/includes/render/class-saddle-render.php
@@ -1,0 +1,209 @@
+<?php
+/**
+ * The builder-agnostic render engine.
+ *
+ * @package Saddle
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Turns persisted page state into the lean, bounded views an agent's eyes
+ * can afford (https://github.com/plugpressco/saddle/issues/24): one node in
+ * detail, or a whole page as a shallow section outline. Everything
+ * builder-specific resolves through Saddle_Render_Accessor; this class only
+ * walks, caps, and sanitizes — an agent must never pay an unbounded token
+ * bill for looking at its own work.
+ */
+class Saddle_Render {
+
+	/**
+	 * Hard cap on returned node HTML, in bytes.
+	 */
+	const HTML_CAP = 2048;
+
+	/**
+	 * Hard cap on an outline entry's text summary, in characters.
+	 */
+	const TEXT_CAP = 80;
+
+	/**
+	 * A detailed view of one node.
+	 *
+	 * @param WP_Post                $post     The post.
+	 * @param array                  $tree     Parsed tree.
+	 * @param string                 $address  Dot address.
+	 * @param Saddle_Render_Accessor $accessor Builder accessor.
+	 * @param string[]               $include  Artifacts to include: 'styles', 'html'.
+	 * @return array|WP_Error
+	 */
+	public static function node( WP_Post $post, array $tree, $address, Saddle_Render_Accessor $accessor, array $include ) {
+		$block = Saddle_Tree::get( $tree, (string) $address );
+		if ( ! $block ) {
+			return new WP_Error(
+				'saddle_render_no_node',
+				sprintf(
+					/* translators: %s: node address. */
+					__( 'No node at address "%s". Re-read the page first — addresses shift when the tree changes.', 'saddle' ),
+					(string) $address
+				),
+				array( 'status' => 404 )
+			);
+		}
+
+		$view = array(
+			'address' => (string) $address,
+			'type'    => (string) $block['blockName'],
+		);
+
+		if ( in_array( 'styles', $include, true ) ) {
+			$view['styles'] = $accessor->effective_styles( $block );
+		}
+
+		if ( in_array( 'html', $include, true ) ) {
+			$html = $accessor->render_node_html( $post, $tree, (string) $address );
+			if ( is_wp_error( $html ) ) {
+				$view['html']      = null;
+				$view['html_note'] = $html->get_error_message();
+			} else {
+				$view['html'] = self::cap_html( (string) $html );
+			}
+			$view['fidelity'] = $accessor->render_fidelity();
+		}
+
+		return $view;
+	}
+
+	/**
+	 * A whole page as a shallow outline: the top-level sections only, each a
+	 * one-line summary — the agent drills into a node by address instead of
+	 * paying for every node's HTML.
+	 *
+	 * @param array                  $tree     Parsed tree.
+	 * @param Saddle_Render_Accessor $accessor Builder accessor.
+	 * @return array[]
+	 */
+	public static function outline( array $tree, Saddle_Render_Accessor $accessor ) {
+		$nodes = Saddle_Lint::nodes( $tree );
+
+		$sections = self::sections( $nodes );
+		$outline  = array();
+		foreach ( $sections as $section ) {
+			$entry = array(
+				'address'  => $section['address'],
+				'type'     => $section['type'],
+				'children' => count( self::children_of( $nodes, $section['address'] ) ),
+			);
+
+			$text = self::text_summary( $nodes, $section );
+			if ( '' !== $text ) {
+				$entry['text'] = $text;
+			}
+
+			$styles = $accessor->effective_styles( $section['block'] );
+			if ( $styles ) {
+				$entry['styles'] = $styles;
+			}
+
+			$outline[] = $entry;
+		}
+		return $outline;
+	}
+
+	/*
+	---------------------------------------------------------------------
+	 * Internals
+	 * -------------------------------------------------------------------
+	 */
+
+	/**
+	 * Cap and sanitize rendered HTML for the agent: script/style bodies and
+	 * HTML comments carry no visual information, whitespace runs are noise,
+	 * and everything past the cap is truncation the agent is told about.
+	 *
+	 * @param string $html Raw rendered HTML.
+	 * @return string
+	 */
+	private static function cap_html( $html ) {
+		$html = preg_replace( '#<(script|style)\b[^>]*>.*?</\1>#is', '', $html );
+		$html = preg_replace( '/<!--.*?-->/s', '', $html );
+		$html = trim( preg_replace( '/\s+/', ' ', $html ) );
+
+		if ( strlen( $html ) > self::HTML_CAP ) {
+			$html = substr( $html, 0, self::HTML_CAP ) . '… [truncated]';
+		}
+		return $html;
+	}
+
+	/**
+	 * The page's top-level sections: root nodes, or — when the page is a
+	 * single root wrapper (Divi's placeholder, a lone all-page group) — that
+	 * wrapper's children. Same convention as the lint rules.
+	 *
+	 * @param array[] $nodes Flat node list (Saddle_Lint::nodes()).
+	 * @return array[]
+	 */
+	private static function sections( array $nodes ) {
+		$roots = self::children_of( $nodes, null );
+		if ( 1 === count( $roots ) ) {
+			$inner = self::children_of( $nodes, $roots[0]['address'] );
+			if ( $inner ) {
+				return $inner;
+			}
+		}
+		return $roots;
+	}
+
+	/**
+	 * Direct children of an address, in order.
+	 *
+	 * @param array[]     $nodes          Flat node list.
+	 * @param string|null $parent_address Parent address (null = roots).
+	 * @return array[]
+	 */
+	private static function children_of( array $nodes, $parent_address ) {
+		$out = array();
+		foreach ( $nodes as $node ) {
+			if ( $node['parent'] === $parent_address ) {
+				$out[] = $node;
+			}
+		}
+		return $out;
+	}
+
+	/**
+	 * A one-line text summary of a section: the first non-empty text found
+	 * in its subtree, capped.
+	 *
+	 * @param array[] $nodes   Flat node list.
+	 * @param array   $section Section node entry.
+	 * @return string
+	 */
+	private static function text_summary( array $nodes, array $section ) {
+		$candidates = array_merge( array( $section ), self::descendants_of( $nodes, $section['address'] ) );
+		foreach ( $candidates as $node ) {
+			$text = trim( wp_strip_all_tags( (string) $node['block']['innerHTML'] ) );
+			if ( '' !== $text ) {
+				return mb_substr( preg_replace( '/\s+/', ' ', $text ), 0, self::TEXT_CAP );
+			}
+		}
+		return '';
+	}
+
+	/**
+	 * All descendants of an address, document order.
+	 *
+	 * @param array[] $nodes    Flat node list.
+	 * @param string  $ancestor Ancestor address.
+	 * @return array[]
+	 */
+	private static function descendants_of( array $nodes, $ancestor ) {
+		$out = array();
+		foreach ( $nodes as $node ) {
+			if ( 0 === strpos( $node['address'] . '.', $ancestor . '.' ) && $node['address'] !== $ancestor ) {
+				$out[] = $node;
+			}
+		}
+		return $out;
+	}
+}

--- a/includes/render/interface-saddle-render-accessor.php
+++ b/includes/render/interface-saddle-render-accessor.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * The builder-specific surface of the render engine.
+ *
+ * @package Saddle
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * How the render engine turns a persisted node into something an agent can
+ * SEE (closed-loop scope, https://github.com/plugpressco/saddle/issues/24).
+ *
+ * Mirrors the lint accessor split: the engine (Saddle_Render) is generic,
+ * and everything builder-specific — how attrs resolve to effective styles,
+ * how a node renders to HTML — lives behind this interface. Free Saddle
+ * implements it for Gutenberg; Saddle Pro's Divi driver implements it for
+ * Divi 5; Elementor/Bricks follow later.
+ *
+ * Both artifacts describe the PERSISTED state (what actually landed in the
+ * database, resolved through presets/globals), never a guess at what an
+ * editor canvas might show.
+ */
+interface Saddle_Render_Accessor {
+
+	/**
+	 * The node's effective styles: persisted attrs merged with whatever
+	 * preset/global indirection the builder supports, resolved to a small
+	 * normalized map (background, color, padding, fontSize, borderRadius,
+	 * gap, textAlign, …). Keys the node doesn't style are omitted.
+	 *
+	 * @param array $node Raw block array (Saddle_Tree::parse() shape).
+	 * @return array Normalized style map; empty when the node styles nothing.
+	 */
+	public function effective_styles( array $node );
+
+	/**
+	 * The node's rendered HTML, as faithful as the builder allows in this
+	 * process. Implementations label their fidelity via render_fidelity().
+	 *
+	 * @param WP_Post $post    The post the tree belongs to.
+	 * @param array   $tree    Full parsed tree (for builders that render in context).
+	 * @param string  $address Dot address of the node to render.
+	 * @return string|WP_Error Rendered HTML, or an error when rendering is
+	 *                         impossible here.
+	 */
+	public function render_node_html( WP_Post $post, array $tree, $address );
+
+	/**
+	 * How faithful render_node_html() is, e.g. 'in-process' (rendered inside
+	 * this request, theme CSS not applied) or 'front-end' (fetched from the
+	 * site's real front end). Surfaced verbatim to the agent so it knows what
+	 * it is looking at.
+	 *
+	 * @return string
+	 */
+	public function render_fidelity();
+}

--- a/saddle.php
+++ b/saddle.php
@@ -52,6 +52,9 @@ require_once SADDLE_DIR . 'includes/lint/rules/class-rule-featured-plan.php';
 require_once SADDLE_DIR . 'includes/lint/rules/class-rule-text-contrast.php';
 require_once SADDLE_DIR . 'includes/lint/rules/class-rule-missing-alt.php';
 require_once SADDLE_DIR . 'includes/lint/rules/class-rule-heading-order.php';
+require_once SADDLE_DIR . 'includes/render/interface-saddle-render-accessor.php';
+require_once SADDLE_DIR . 'includes/render/class-saddle-render.php';
+require_once SADDLE_DIR . 'includes/render/class-saddle-render-gutenberg-accessor.php';
 require_once SADDLE_DIR . 'includes/class-saddle-capabilities.php';
 require_once SADDLE_DIR . 'includes/class-saddle-approval.php';
 require_once SADDLE_DIR . 'includes/class-saddle-context.php';
@@ -110,6 +113,7 @@ final class Saddle {
 			require_once SADDLE_DIR . 'includes/abilities/users.php';
 			require_once SADDLE_DIR . 'includes/abilities/context.php';
 			require_once SADDLE_DIR . 'includes/abilities/lint.php';
+			require_once SADDLE_DIR . 'includes/abilities/render.php';
 			require_once SADDLE_DIR . 'includes/abilities/memory.php';
 			add_action( 'wp_abilities_api_categories_init', 'saddle_register_ability_category' );
 			add_action( 'wp_abilities_api_init', 'saddle_register_abilities' );
@@ -118,6 +122,7 @@ final class Saddle {
 			add_action( 'wp_abilities_api_init', 'saddle_register_user_abilities' );
 			add_action( 'wp_abilities_api_init', 'saddle_register_context_abilities' );
 			add_action( 'wp_abilities_api_init', 'saddle_register_lint_abilities' );
+			add_action( 'wp_abilities_api_init', 'saddle_register_render_abilities' );
 			add_action( 'wp_abilities_api_init', 'saddle_register_memory_abilities' );
 			// First-party integration wrappers run late (30) so the partner
 			// plugins' own abilities exist to discover.

--- a/tests/render-test.php
+++ b/tests/render-test.php
@@ -1,0 +1,195 @@
+<?php
+/**
+ * The render engine + the saddle/render-node ability.
+ *
+ * Pins the agent's eyes (https://github.com/plugpressco/saddle/issues/24):
+ * effective styles resolved from persisted attrs, rendered HTML capped and
+ * sanitized, whole-page reads bounded to a section outline, and builder
+ * pages resolved through the one accessor filter — exactly the lint pattern.
+ *
+ * @package Saddle
+ */
+
+class Saddle_Render_Test extends WP_UnitTestCase {
+
+	private $admin;
+
+	public function set_up() {
+		parent::set_up();
+		$this->admin = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $this->admin );
+	}
+
+	public function tear_down() {
+		remove_all_filters( 'saddle_render_accessor' );
+		parent::tear_down();
+	}
+
+	/* -------- helpers -------- */
+
+	private function page( $content ) {
+		return self::factory()->post->create(
+			array(
+				'post_type'    => 'page',
+				'post_content' => $content,
+			)
+		);
+	}
+
+	private function run_ability( array $input ) {
+		$ability = wp_get_ability( 'saddle/render-node' );
+		$this->assertNotNull( $ability, 'saddle/render-node must be registered.' );
+		return $ability->execute( $input );
+	}
+
+	private function hero_markup() {
+		return '<!-- wp:group {"style":{"color":{"background":"#0a2540"},"spacing":{"padding":{"top":"96px","bottom":"96px"}}}} -->'
+			. '<div class="wp-block-group">'
+			. '<!-- wp:heading --><h2 class="wp-block-heading">Ship faster</h2><!-- /wp:heading -->'
+			. '<!-- wp:paragraph {"style":{"color":{"text":"#ffffff"},"typography":{"fontSize":"18px"}}} --><p>Do the thing.</p><!-- /wp:paragraph -->'
+			. '</div><!-- /wp:group -->'
+			. '<!-- wp:paragraph --><p>Second section.</p><!-- /wp:paragraph -->';
+	}
+
+	/* -------- registration + tier -------- */
+
+	public function test_render_node_is_read_tier_and_readonly() {
+		$meta = wp_get_ability( 'saddle/render-node' )->get_meta();
+		$this->assertSame( 'read', $meta['saddle']['tier'] );
+		$this->assertTrue( $meta['annotations']['readonly'] );
+		$this->assertFalse( $meta['annotations']['destructive'] );
+	}
+
+	/* -------- one node: styles + html -------- */
+
+	public function test_node_view_resolves_effective_styles_and_renders_html() {
+		$id     = $this->page( $this->hero_markup() );
+		$result = $this->run_ability(
+			array(
+				'post_id' => $id,
+				'address' => '0.1',
+			)
+		);
+
+		$this->assertNotWPError( $result );
+		$this->assertSame( '0.1', $result['address'] );
+		$this->assertSame( 'core/paragraph', $result['type'] );
+		$this->assertSame( '#ffffff', $result['styles']['color'] );
+		$this->assertSame( '18px', $result['styles']['fontSize'] );
+		$this->assertStringContainsString( 'Do the thing.', $result['html'] );
+		$this->assertSame( 'in-process', $result['fidelity'] );
+	}
+
+	public function test_include_styles_only_omits_html() {
+		$id     = $this->page( $this->hero_markup() );
+		$result = $this->run_ability(
+			array(
+				'post_id' => $id,
+				'address' => '0.1',
+				'include' => array( 'styles' ),
+			)
+		);
+
+		$this->assertArrayHasKey( 'styles', $result );
+		$this->assertArrayNotHasKey( 'html', $result );
+		$this->assertArrayNotHasKey( 'fidelity', $result );
+	}
+
+	public function test_html_is_capped_and_stripped_of_script() {
+		$long = str_repeat( 'All work and no play makes an agent a dull tool. ', 200 );
+		$id   = $this->page(
+			'<!-- wp:paragraph --><p><script>alert(1)</script>' . $long . '</p><!-- /wp:paragraph -->'
+		);
+
+		$result = $this->run_ability(
+			array(
+				'post_id' => $id,
+				'address' => '0',
+			)
+		);
+
+		$this->assertStringNotContainsString( '<script', $result['html'] );
+		$this->assertStringContainsString( '[truncated]', $result['html'] );
+		$this->assertLessThanOrEqual( Saddle_Render::HTML_CAP + 32, strlen( $result['html'] ) );
+	}
+
+	public function test_unknown_address_is_a_clean_error() {
+		$id     = $this->page( $this->hero_markup() );
+		$result = $this->run_ability(
+			array(
+				'post_id' => $id,
+				'address' => '9.9.9',
+			)
+		);
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'saddle_render_no_node', $result->get_error_code() );
+	}
+
+	/* -------- whole page: the outline -------- */
+
+	public function test_whole_page_returns_a_bounded_outline() {
+		$id     = $this->page( $this->hero_markup() );
+		$result = $this->run_ability( array( 'post_id' => $id ) );
+
+		$this->assertNotWPError( $result );
+		$this->assertSame( 'native', $result['builder'] );
+		$this->assertSame( 2, $result['count'] );
+
+		$hero = $result['outline'][0];
+		$this->assertSame( '0', $hero['address'] );
+		$this->assertSame( 'core/group', $hero['type'] );
+		$this->assertSame( 2, $hero['children'] );
+		$this->assertSame( 'Ship faster', $hero['text'] );
+		$this->assertSame( '#0a2540', $hero['styles']['background'] );
+
+		// The outline never carries node HTML — that is what drilling in is for.
+		$this->assertArrayNotHasKey( 'html', $hero );
+	}
+
+	public function test_single_wrapper_pages_outline_their_children() {
+		$id     = $this->page(
+			'<!-- wp:group --><div class="wp-block-group">'
+			. '<!-- wp:heading --><h2 class="wp-block-heading">A</h2><!-- /wp:heading -->'
+			. '<!-- wp:paragraph --><p>B</p><!-- /wp:paragraph -->'
+			. '</div><!-- /wp:group -->'
+		);
+		$result = $this->run_ability( array( 'post_id' => $id ) );
+
+		$this->assertSame( 2, $result['count'], 'A lone root wrapper outlines its children, like the lint rules.' );
+		$this->assertSame( '0.0', $result['outline'][0]['address'] );
+	}
+
+	/* -------- builder resolution -------- */
+
+	public function test_builder_page_without_accessor_is_refused() {
+		$id     = $this->page( '<!-- wp:divi/placeholder --><!-- wp:divi/section --><!-- /wp:divi/section --><!-- /wp:divi/placeholder -->' );
+		$result = $this->run_ability( array( 'post_id' => $id ) );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'saddle_render_unsupported', $result->get_error_code() );
+	}
+
+	public function test_builder_page_uses_the_accessor_an_integration_provides() {
+		add_filter(
+			'saddle_render_accessor',
+			static function ( $accessor, $builder ) {
+				return 'Divi 5' === $builder ? new Saddle_Render_Gutenberg_Accessor() : $accessor;
+			},
+			10,
+			2
+		);
+
+		$id     = $this->page( '<!-- wp:divi/placeholder --><!-- wp:divi/section --><!-- /wp:divi/section --><!-- /wp:divi/placeholder -->' );
+		$result = $this->run_ability( array( 'post_id' => $id ) );
+
+		$this->assertNotWPError( $result );
+		$this->assertSame( 'Divi 5', $result['builder'] );
+	}
+
+	public function test_missing_post_is_not_found() {
+		$result = $this->run_ability( array( 'post_id' => 999999 ) );
+		$this->assertWPError( $result );
+		$this->assertSame( 'saddle_not_found', $result->get_error_code() );
+	}
+}


### PR DESCRIPTION
Closes #24 — Pillar 1's free half ([epic #22](https://github.com/plugpressco/saddle/issues/22), build step F2).

## What

The agent gets to **see** the effective result of what it built — in-process, no third-party custody, no browser.

- **`Saddle_Render_Accessor`** — the one builder surface (`effective_styles`, `render_node_html`, `render_fidelity`), mirroring the lint accessor split.
- **`Saddle_Render`** — generic engine: one node in detail, or a whole page as a **bounded section outline** (drill in by address instead of paying for every node's HTML). HTML stripped of script/style/comments, hard-capped at 2KB with a visible `[truncated]` marker.
- **Gutenberg accessor** — effective styles **compose the lint accessor's resolution** (one resolver; lint and render can never disagree about a preset slug), HTML via core's `render_block()`, fidelity `in-process`.
- **`saddle/render-node`** (read tier) — native pages use the Gutenberg accessor; builder pages resolve via the new **`saddle_render_accessor` filter**, ready for Pro's Divi driver (P1 / saddle-pro#9).

## Tests

`tests/render-test.php` — 10 tests: style resolution, include selection, HTML cap + script stripping, unknown-address error, bounded outline, lone-wrapper outlining, builder refusal + filter resolution, tier meta.

Free **281 green** (+10) · Pro **119 green** · phpcs clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)