### PR TITLE
F3: preview transport + saddle/get-preview-url

### DIFF
--- a/includes/abilities/render.php
+++ b/includes/abilities/render.php
@@ -52,6 +52,28 @@ function saddle_register_render_abilities() {
 			'meta'                => saddle_ability_meta( true, false, true, 'read' ),
 		)
 	);
+
+	wp_register_ability(
+		'saddle/get-preview-url',
+		array(
+			'label'               => __( 'Get a preview URL', 'saddle' ),
+			'description'         => __( 'Returns a short-lived, signed URL that renders the post\'s CURRENT saved layout on the site\'s own front end — drafts included, no login needed, expires in about 5 minutes. This is how you SEE real pixels: open the URL in your own browser and screenshot it (Saddle never renders or sends anything anywhere). The page is noindex and the link opens only this one post; treat it as ephemeral and do not share it.', 'saddle' ),
+			'category'            => 'saddle',
+			'input_schema'        => array(
+				'type'       => 'object',
+				'required'   => array( 'post_id' ),
+				'properties' => array(
+					'post_id' => array(
+						'type'        => 'integer',
+						'description' => __( 'The post or page to preview.', 'saddle' ),
+					),
+				),
+			),
+			'execute_callback'    => array( 'Saddle_Render_Abilities', 'get_preview_url' ),
+			'permission_callback' => Saddle_Capabilities::permission( 'read', 'read', 'get-preview-url' ),
+			'meta'                => saddle_ability_meta( true, false, false, 'read' ),
+		)
+	);
 }
 
 /**
@@ -107,6 +129,39 @@ class Saddle_Render_Abilities {
 			array(
 				'note' => __( 'Effective persisted styles with presets/tokens resolved — what the saved state means, not a browser screenshot.', 'saddle' ),
 			)
+		);
+	}
+
+	/**
+	 * saddle/get-preview-url.
+	 *
+	 * A preview link exposes unpublished content to whoever holds it, so the
+	 * caller must be allowed to SEE that content first: published posts need
+	 * read access, anything else needs edit rights — a read-only viewer must
+	 * not mint a window into someone's draft.
+	 *
+	 * @param array $input Ability input.
+	 * @return array|WP_Error
+	 */
+	public static function get_preview_url( $input = null ) {
+		$input = is_array( $input ) ? $input : array();
+		$post  = get_post( isset( $input['post_id'] ) ? (int) $input['post_id'] : 0 );
+		if ( ! $post || ! in_array( $post->post_type, array( 'post', 'page' ), true ) ) {
+			return new WP_Error( 'saddle_not_found', __( 'No post or page with that ID.', 'saddle' ), array( 'status' => 404 ) );
+		}
+
+		$cap = 'publish' === $post->post_status ? 'read_post' : 'edit_post';
+		if ( ! current_user_can( $cap, $post->ID ) ) {
+			return new WP_Error( 'saddle_forbidden', __( 'You cannot preview this post.', 'saddle' ), array( 'status' => 403 ) );
+		}
+
+		$minted = Saddle_Preview::mint( $post );
+
+		return array(
+			'id'         => $post->ID,
+			'url'        => $minted['url'],
+			'expires_in' => $minted['expires_in'],
+			'note'       => __( 'Open and screenshot this in YOUR browser — it renders the current saved layout (drafts included) on the site\'s own front end, is noindex, opens only this post, and expires. Do not share it.', 'saddle' ),
 		);
 	}
 

--- a/includes/preview/class-saddle-preview.php
+++ b/includes/preview/class-saddle-preview.php
@@ -1,0 +1,225 @@
+<?php
+/**
+ * Tokenized front-end previews — the safe window the agent's own client
+ * screenshots.
+ *
+ * @package Saddle
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Real pixels without custody (https://github.com/plugpressco/saddle/issues/25):
+ * Saddle never renders or screenshots anything itself — it mints a signed,
+ * short-lived URL onto the site's OWN front end, and the agent's MCP client
+ * (which has a browser) does the seeing. Nothing leaves the install.
+ *
+ * The serving mechanic is the proven public-preview pattern: the URL carries
+ * `preview=1` plus an HMAC token; when the token verifies, the main query's
+ * post is flipped to publish IN MEMORY (core's read-cap enforcement for
+ * non-public statuses runs after `posts_results`, so the flip is exactly the
+ * sanctioned hook point). The token — not a login — is the access control:
+ * post-bound, 5-minute TTL, HMAC over a rotating site-local secret. Previews
+ * are marked noindex and never listed anywhere.
+ */
+class Saddle_Preview {
+
+	/**
+	 * Token lifetime, in seconds. Long enough to open and screenshot, short
+	 * enough that a leaked URL goes stale before it travels.
+	 */
+	const TTL = 300;
+
+	/**
+	 * Query arg carrying the token.
+	 */
+	const QUERY_ARG = 'saddle_preview';
+
+	/**
+	 * Option holding { secret, previous, rotated }.
+	 */
+	const OPTION = 'saddle_preview_secret';
+
+	/**
+	 * Rotate the signing secret when older than this. Verification accepts
+	 * the previous secret too, so rotation never breaks a just-minted token.
+	 */
+	const ROTATE_AFTER = DAY_IN_SECONDS;
+
+	/**
+	 * Hook the serving path. Called unconditionally from the bootstrap —
+	 * serving a token must work even when the Abilities API is absent.
+	 */
+	public static function register() {
+		add_filter( 'posts_results', array( __CLASS__, 'filter_posts_results' ), 10, 2 );
+		add_action( 'template_redirect', array( __CLASS__, 'harden_response' ), 0 );
+	}
+
+	/**
+	 * Mint a preview URL for a post.
+	 *
+	 * @param WP_Post $post The post.
+	 * @return array { url, expires_in }
+	 */
+	public static function mint( WP_Post $post ) {
+		$expires = time() + self::TTL;
+		$token   = $expires . '.' . self::signature( $post->ID, $expires, self::secrets()['secret'] );
+
+		$args = array(
+			'preview'       => 1,
+			self::QUERY_ARG => $token,
+		);
+		// Hierarchical types resolve by page_id, everything else by p.
+		if ( is_post_type_hierarchical( $post->post_type ) ) {
+			$args['page_id'] = $post->ID;
+		} else {
+			$args['p'] = $post->ID;
+		}
+
+		return array(
+			'url'        => add_query_arg( $args, home_url( '/' ) ),
+			'expires_in' => self::TTL,
+		);
+	}
+
+	/**
+	 * Whether a token grants a view of a post right now.
+	 *
+	 * @param string $token   Token from the URL.
+	 * @param int    $post_id The post the request resolves to.
+	 * @return bool
+	 */
+	public static function verify( $token, $post_id ) {
+		$parts = explode( '.', (string) $token, 2 );
+		if ( 2 !== count( $parts ) ) {
+			return false;
+		}
+		list( $expires, $signature ) = $parts;
+		$expires                     = (int) $expires;
+		if ( $expires < time() ) {
+			return false;
+		}
+
+		$secrets = self::secrets();
+		foreach ( array( $secrets['secret'], $secrets['previous'] ) as $secret ) {
+			if ( '' !== $secret && hash_equals( self::signature( (int) $post_id, $expires, $secret ), $signature ) ) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	/**
+	 * Serve a verified preview: flip the queried post to publish in memory so
+	 * core's public-status check (which runs after this filter) lets the
+	 * site's own front end render it. The flip is bound to the exact post the
+	 * token signs — a token for one draft opens nothing else.
+	 *
+	 * @param WP_Post[] $posts Main-query results.
+	 * @param WP_Query  $query The query.
+	 * @return WP_Post[]
+	 */
+	public static function filter_posts_results( $posts, $query ) {
+		if ( ! self::requested() || ! $query->is_main_query() || 1 !== count( $posts ) ) {
+			return $posts;
+		}
+		if ( ! $query->is_preview() || ! $query->is_singular() ) {
+			return $posts;
+		}
+
+		$post = $posts[0];
+		if ( ! self::verify( self::requested(), $post->ID ) ) {
+			return $posts;
+		}
+
+		if ( 'publish' !== $post->post_status ) {
+			$posts[0]->post_status = 'publish';
+		}
+		return $posts;
+	}
+
+	/**
+	 * Mark an active preview response noindex and chrome-free.
+	 */
+	public static function harden_response() {
+		if ( ! self::requested() || ! is_singular() ) {
+			return;
+		}
+		// Only harden when the token actually verified for this very post —
+		// a garbage token on a public URL is just a normal page view.
+		if ( ! self::verify( self::requested(), get_queried_object_id() ) ) {
+			return;
+		}
+
+		if ( ! headers_sent() ) {
+			header( 'X-Robots-Tag: noindex, nofollow' );
+		}
+		add_filter( 'wp_robots', 'wp_robots_no_robots' );
+		show_admin_bar( false );
+	}
+
+	/*
+	---------------------------------------------------------------------
+	 * Internals
+	 * -------------------------------------------------------------------
+	 */
+
+	/**
+	 * The raw token from the request, or '' when none.
+	 *
+	 * @return string
+	 */
+	private static function requested() {
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- The HMAC token IS the verification.
+		return isset( $_GET[ self::QUERY_ARG ] ) ? sanitize_text_field( wp_unslash( $_GET[ self::QUERY_ARG ] ) ) : '';
+	}
+
+	/**
+	 * HMAC over the (post, expiry) pair.
+	 *
+	 * @param int    $post_id Post id.
+	 * @param int    $expires Expiry timestamp.
+	 * @param string $secret  Signing secret.
+	 * @return string
+	 */
+	private static function signature( $post_id, $expires, $secret ) {
+		return hash_hmac( 'sha256', $post_id . '|' . $expires, $secret );
+	}
+
+	/**
+	 * The signing secrets, created on first use and rotated lazily. The
+	 * previous secret stays valid so rotation can never invalidate a token
+	 * younger than its TTL.
+	 *
+	 * @return array { secret, previous, rotated }
+	 */
+	private static function secrets() {
+		$stored = get_option( self::OPTION );
+		$stored = is_array( $stored ) ? $stored : array();
+
+		$secret   = isset( $stored['secret'] ) && is_string( $stored['secret'] ) ? $stored['secret'] : '';
+		$previous = isset( $stored['previous'] ) && is_string( $stored['previous'] ) ? $stored['previous'] : '';
+		$rotated  = isset( $stored['rotated'] ) ? (int) $stored['rotated'] : 0;
+
+		if ( '' === $secret || ( time() - $rotated ) > self::ROTATE_AFTER ) {
+			$previous = $secret;
+			$secret   = wp_generate_password( 64, false );
+			$rotated  = time();
+			update_option(
+				self::OPTION,
+				array(
+					'secret'   => $secret,
+					'previous' => $previous,
+					'rotated'  => $rotated,
+				),
+				false
+			);
+		}
+
+		return array(
+			'secret'   => $secret,
+			'previous' => $previous,
+			'rotated'  => $rotated,
+		);
+	}
+}

--- a/saddle.php
+++ b/saddle.php
@@ -55,6 +55,7 @@ require_once SADDLE_DIR . 'includes/lint/rules/class-rule-heading-order.php';
 require_once SADDLE_DIR . 'includes/render/interface-saddle-render-accessor.php';
 require_once SADDLE_DIR . 'includes/render/class-saddle-render.php';
 require_once SADDLE_DIR . 'includes/render/class-saddle-render-gutenberg-accessor.php';
+require_once SADDLE_DIR . 'includes/preview/class-saddle-preview.php';
 require_once SADDLE_DIR . 'includes/class-saddle-capabilities.php';
 require_once SADDLE_DIR . 'includes/class-saddle-approval.php';
 require_once SADDLE_DIR . 'includes/class-saddle-context.php';
@@ -87,6 +88,9 @@ final class Saddle {
 		add_action( 'wp_authenticate_application_password_errors', array( 'Saddle_Connection', 'block_xmlrpc_credentials' ), 10, 3 );
 
 		// Always-on infrastructure (independent of the Abilities API).
+		// The preview serving path stays up even when minting isn't — an
+		// outstanding token must keep working for its full (short) life.
+		Saddle_Preview::register();
 		add_action( 'init', array( 'Saddle_Approval', 'register_cpt' ) );
 		add_action( 'init', array( 'Saddle_Log', 'register_cpt' ) );
 		add_action( 'init', array( 'Saddle_Skills', 'register_cpt' ) );

--- a/tests/preview-test.php
+++ b/tests/preview-test.php
@@ -1,0 +1,164 @@
+<?php
+/**
+ * The preview transport + the saddle/get-preview-url ability.
+ *
+ * Pins the no-custody screenshot path (https://github.com/plugpressco/saddle/issues/25):
+ * HMAC tokens are post-bound and expire, rotation never breaks a live token,
+ * a valid token lets the site's own front end serve a draft to an anonymous
+ * visitor, an invalid one changes nothing, and minting demands the right to
+ * see the content first.
+ *
+ * @package Saddle
+ */
+
+class Saddle_Preview_Test extends WP_UnitTestCase {
+
+	private $admin;
+
+	public function set_up() {
+		parent::set_up();
+		$this->admin = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $this->admin );
+	}
+
+	public function tear_down() {
+		delete_option( Saddle_Preview::OPTION );
+		$_GET = array();
+		parent::tear_down();
+	}
+
+	/* -------- helpers -------- */
+
+	private function draft_page( $title = 'Secret draft' ) {
+		return get_post(
+			self::factory()->post->create(
+				array(
+					'post_type'    => 'page',
+					'post_status'  => 'draft',
+					'post_title'   => $title,
+					'post_content' => '<!-- wp:paragraph --><p>Hidden copy.</p><!-- /wp:paragraph -->',
+				)
+			)
+		);
+	}
+
+	private function token_from( $url ) {
+		parse_str( (string) wp_parse_url( $url, PHP_URL_QUERY ), $query );
+		return isset( $query[ Saddle_Preview::QUERY_ARG ] ) ? $query[ Saddle_Preview::QUERY_ARG ] : '';
+	}
+
+	/* -------- mint + verify -------- */
+
+	public function test_mint_produces_a_bound_expiring_url() {
+		$post   = $this->draft_page();
+		$minted = Saddle_Preview::mint( $post );
+
+		$this->assertSame( Saddle_Preview::TTL, $minted['expires_in'] );
+		$this->assertStringContainsString( 'preview=1', $minted['url'] );
+		$this->assertStringContainsString( 'page_id=' . $post->ID, $minted['url'], 'Hierarchical types resolve by page_id.' );
+
+		$token = $this->token_from( $minted['url'] );
+		$this->assertTrue( Saddle_Preview::verify( $token, $post->ID ) );
+	}
+
+	public function test_token_is_post_bound_and_garbage_fails() {
+		$post  = $this->draft_page();
+		$other = $this->draft_page( 'Another' );
+		$token = $this->token_from( Saddle_Preview::mint( $post )['url'] );
+
+		$this->assertFalse( Saddle_Preview::verify( $token, $other->ID ), 'A token opens ONLY the post it signs.' );
+		$this->assertFalse( Saddle_Preview::verify( 'garbage', $post->ID ) );
+		$this->assertFalse( Saddle_Preview::verify( '', $post->ID ) );
+	}
+
+	public function test_expired_token_fails() {
+		$post  = $this->draft_page();
+		$token = $this->token_from( Saddle_Preview::mint( $post )['url'] );
+
+		// Split and rebuild with a past expiry — the signature no longer matches.
+		list( , $signature ) = explode( '.', $token, 2 );
+		$this->assertFalse( Saddle_Preview::verify( ( time() - 10 ) . '.' . $signature, $post->ID ) );
+	}
+
+	public function test_rotation_keeps_the_previous_secret_valid() {
+		$post  = $this->draft_page();
+		$token = $this->token_from( Saddle_Preview::mint( $post )['url'] );
+
+		// Force a rotation by backdating the stored timestamp past the window.
+		$stored            = get_option( Saddle_Preview::OPTION );
+		$stored['rotated'] = time() - Saddle_Preview::ROTATE_AFTER - 10;
+		update_option( Saddle_Preview::OPTION, $stored, false );
+		Saddle_Preview::mint( $post ); // Triggers the lazy rotation.
+
+		$this->assertNotSame( $stored['secret'], get_option( Saddle_Preview::OPTION )['secret'], 'The secret rotated.' );
+		$this->assertTrue( Saddle_Preview::verify( $token, $post->ID ), 'A live token survives one rotation.' );
+	}
+
+	/* -------- serving: the site's own front end -------- */
+
+	public function test_valid_token_serves_a_draft_to_an_anonymous_visitor() {
+		$post = $this->draft_page();
+		$url  = Saddle_Preview::mint( $post )['url'];
+
+		wp_set_current_user( 0 );
+		$this->go_to( $url );
+
+		$this->assertTrue( is_singular(), 'The preview resolves to the single post.' );
+		$this->assertSame( $post->ID, get_queried_object_id() );
+		$this->assertSame( 'publish', get_queried_object()->post_status, 'The in-memory flip lets the front end render the draft.' );
+	}
+
+	public function test_bad_token_serves_nothing_anonymous() {
+		$post = $this->draft_page();
+		$url  = Saddle_Preview::mint( $post )['url'];
+		$url  = preg_replace( '/saddle_preview=[^&]+/', 'saddle_preview=' . rawurlencode( ( time() + 100 ) . '.forged' ), $url );
+
+		wp_set_current_user( 0 );
+		$this->go_to( $url );
+
+		$this->assertNotSame( $post->ID, get_queried_object_id(), 'A forged token opens nothing.' );
+	}
+
+	/* -------- the ability -------- */
+
+	private function run_ability( array $input ) {
+		$ability = wp_get_ability( 'saddle/get-preview-url' );
+		$this->assertNotNull( $ability, 'saddle/get-preview-url must be registered.' );
+		return $ability->execute( $input );
+	}
+
+	public function test_ability_mints_for_an_editor() {
+		$post   = $this->draft_page();
+		$result = $this->run_ability( array( 'post_id' => $post->ID ) );
+
+		$this->assertNotWPError( $result );
+		$this->assertSame( $post->ID, $result['id'] );
+		$this->assertSame( Saddle_Preview::TTL, $result['expires_in'] );
+		$this->assertTrue( Saddle_Preview::verify( $this->token_from( $result['url'] ), $post->ID ) );
+	}
+
+	public function test_ability_refuses_drafts_to_callers_without_edit_rights() {
+		$post       = $this->draft_page();
+		$subscriber = self::factory()->user->create( array( 'role' => 'subscriber' ) );
+		wp_set_current_user( $subscriber );
+
+		$result = $this->run_ability( array( 'post_id' => $post->ID ) );
+		$this->assertWPError( $result, 'A read-only viewer must not mint a window into a draft.' );
+		$this->assertSame( 'saddle_forbidden', $result->get_error_code() );
+	}
+
+	public function test_ability_allows_published_posts_to_readers() {
+		$id         = self::factory()->post->create( array( 'post_status' => 'publish' ) );
+		$subscriber = self::factory()->user->create( array( 'role' => 'subscriber' ) );
+		wp_set_current_user( $subscriber );
+
+		$result = $this->run_ability( array( 'post_id' => $id ) );
+		$this->assertNotWPError( $result, 'Published content is already public — minting is fine.' );
+	}
+
+	public function test_ability_is_read_tier_and_readonly() {
+		$meta = wp_get_ability( 'saddle/get-preview-url' )->get_meta();
+		$this->assertSame( 'read', $meta['saddle']['tier'] );
+		$this->assertTrue( $meta['annotations']['readonly'] );
+	}
+}

--- a/uninstall.php
+++ b/uninstall.php
@@ -25,6 +25,7 @@ $saddle_options = array(
 	'saddle_memory_max_entries',      // Saddle_Memory::OPTION_MAX_ENTRIES.
 	'saddle_memory_autoinject_agent', // Saddle_Memory::OPTION_AUTOINJECT.
 	'saddle_memory_core_budget',      // Saddle_Memory::OPTION_CORE_BUDGET.
+	'saddle_preview_secret',          // Saddle_Preview::OPTION.
 );
 foreach ( $saddle_options as $saddle_option ) {
 	delete_option( $saddle_option );


### PR DESCRIPTION
Closes #25 — Pillar 1's real-pixels path ([epic #22](https://github.com/plugpressco/saddle/issues/22), build step F3).

## What

Saddle never renders or screenshots anything itself — it mints a **signed, short-lived URL onto the site's own front end**, and the agent's MCP client (which has a browser) does the seeing. Nothing leaves the install; the no-custody rule holds.

- **`Saddle_Preview`** — HMAC tokens (post-bound, 5-min TTL) over a rotating site-local secret; the previous secret stays valid through one rotation so a live token never breaks. Serving uses the proven public-preview mechanic: on a verified token, the queried post is flipped to publish **in memory** at `posts_results` (core's public-status enforcement runs right after — the sanctioned hook point). Responses: `X-Robots-Tag: noindex`, `wp_robots_no_robots`, no admin bar. Registered unconditionally so an outstanding token keeps working.
- **`saddle/get-preview-url`** (read tier) — minting demands the right to *see* the content first: published → read access, drafts → **edit rights**. A read-only viewer can never mint a window into someone's draft.
- `uninstall.php` clears the secret option.

## Tests

10 tests: bound+expiring mint, post-binding, forgery/expiry refusal, rotation survival, the **anonymous end-to-end draft serve** via `go_to()`, forged-token nothing-happens, and the ability's permission split.

Free **291 green** (+10) · Pro **119 green** · phpcs clean.

Remaining manual check (tracked on the issue): open a minted URL in Claude Code and screenshot it on a real site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)