### PR TITLE
F4: verify-page — the closed-loop engine

### DIFF
--- a/includes/abilities/verify.php
+++ b/includes/abilities/verify.php
@@ -1,0 +1,103 @@
+<?php
+/**
+ * The verify ability — the closed loop's checkpoint.
+ *
+ * saddle/verify-page re-reads a page's PERSISTED state and returns one
+ * scored, loopable report: structural soundness, silently-ignored attrs
+ * (echo), and design/accessibility judgments (lint). Addresses match the
+ * page-read tools, so an agent fixes by address and re-verifies
+ * (https://github.com/plugpressco/saddle/issues/26).
+ *
+ * @package Saddle
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Register the verify ability. Hooked to `wp_abilities_api_init`.
+ */
+function saddle_register_verify_abilities() {
+
+	wp_register_ability(
+		'saddle/verify-page',
+		array(
+			'label'               => __( 'Verify a page', 'saddle' ),
+			'description'         => __( 'Re-reads a page\'s SAVED state and returns one scored report (0–100 + grade): structural problems, attributes the builder silently ignores (your styling never took effect), and design/accessibility violations — each finding at a node address with a fix hint. Run it after building or editing: fix structural and "ignored" findings first, then errors, then re-run until the score is acceptable. This is how you know your work actually landed, not just that the write calls returned.', 'saddle' ),
+			'category'            => 'saddle',
+			'input_schema'        => array(
+				'type'       => 'object',
+				'required'   => array( 'post_id' ),
+				'properties' => array(
+					'post_id' => array(
+						'type'        => 'integer',
+						'description' => __( 'The post or page to verify.', 'saddle' ),
+					),
+				),
+			),
+			'execute_callback'    => array( 'Saddle_Verify_Abilities', 'verify_page' ),
+			'permission_callback' => Saddle_Capabilities::permission( 'read', 'read', 'verify-page' ),
+			'meta'                => saddle_ability_meta( true, false, true, 'read' ),
+		)
+	);
+}
+
+/**
+ * Execute callbacks for the verify ability.
+ */
+class Saddle_Verify_Abilities {
+
+	/**
+	 * saddle/verify-page.
+	 *
+	 * @param array $input Ability input.
+	 * @return array|WP_Error
+	 */
+	public static function verify_page( $input = null ) {
+		$input = is_array( $input ) ? $input : array();
+		$post  = get_post( isset( $input['post_id'] ) ? (int) $input['post_id'] : 0 );
+		if ( ! $post || ! in_array( $post->post_type, array( 'post', 'page' ), true ) ) {
+			return new WP_Error( 'saddle_not_found', __( 'No post or page with that ID.', 'saddle' ), array( 'status' => 404 ) );
+		}
+		if ( ! current_user_can( 'read_post', $post->ID ) ) {
+			return new WP_Error( 'saddle_forbidden', __( 'You cannot read this post.', 'saddle' ), array( 'status' => 403 ) );
+		}
+
+		$builder  = Saddle_Abilities::builder_signature( $post );
+		$accessor = null === $builder ? new Saddle_Lint_Gutenberg_Accessor() : null;
+
+		/** This filter is documented in includes/abilities/lint.php */
+		$accessor = apply_filters( 'saddle_lint_accessor', $accessor, $builder, $post );
+		if ( ! $accessor instanceof Saddle_Lint_Accessor ) {
+			$accessor = null;
+		}
+
+		$report = Saddle_Verify::run( $post, $builder, $accessor );
+
+		// A builder page where NOTHING could run isn't a report, it's a gap.
+		if ( count( $report['skipped'] ) >= 3 ) {
+			return new WP_Error(
+				'saddle_verify_unsupported',
+				sprintf(
+					/* translators: 1: post ID, 2: builder name. */
+					__( 'Post #%1$d is built with %2$s, and no verifier for that builder is installed. Divi 5 pages need Saddle Pro.', 'saddle' ),
+					$post->ID,
+					(string) $builder
+				),
+				array( 'status' => 409 )
+			);
+		}
+
+		return array_merge(
+			array(
+				'id'      => $post->ID,
+				'builder' => null === $builder ? 'native' : $builder,
+			),
+			$report,
+			array(
+				'note' => $report['findings']
+					? __( 'Fix in order: structural, then "ignored" (echo — that styling never took effect), then errors, then warnings. Addresses match get-blocks/divi-get-page; re-read after structural edits, then re-run verify-page until the score is acceptable.', 'saddle' )
+					: __( 'Everything checked out: the persisted state is structurally sound, every attribute takes effect, and no design violations were found.', 'saddle' ),
+			)
+		);
+	}
+}

--- a/includes/lint/class-saddle-lint.php
+++ b/includes/lint/class-saddle-lint.php
@@ -127,13 +127,14 @@ class Saddle_Lint {
 	}
 
 	/**
-	 * Document-order comparison of two violations by dot address.
+	 * Document-order comparison of two violations by dot address. Public:
+	 * the verify engine sorts its merged findings with the same ordering.
 	 *
 	 * @param array $a First violation.
 	 * @param array $b Second violation.
 	 * @return int
 	 */
-	private static function compare_addresses( array $a, array $b ) {
+	public static function compare_addresses( array $a, array $b ) {
 		$pa = '' === $a['address'] ? array() : array_map( 'intval', explode( '.', $a['address'] ) );
 		$pb = '' === $b['address'] ? array() : array_map( 'intval', explode( '.', $b['address'] ) );
 

--- a/includes/verify/class-saddle-verify.php
+++ b/includes/verify/class-saddle-verify.php
@@ -1,0 +1,325 @@
+<?php
+/**
+ * The closed-loop verify engine.
+ *
+ * @package Saddle
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * One scored answer to "did what I built actually land, and is it any good?"
+ * (https://github.com/plugpressco/saddle/issues/26).
+ *
+ * Three passes over FRESHLY RE-READ persisted state — the re-read is the
+ * whole point: it proves what is in the database, not what a write call
+ * claimed:
+ *
+ *  1. structural — does the persisted tree hold together at all;
+ *  2. echo — persisted attrs the builder will silently IGNORE (the intended
+ *     design didn't take effect, the worst kind of failure because nothing
+ *     errored);
+ *  3. lint — the design/accessibility judgment rules.
+ *
+ * Findings merge into one deduped, document-ordered, capped list, every one
+ * keyed by the same dot address the page-read tools emit — so an agent
+ * loops: read → verify → fix the flagged address → re-verify. The score is
+ * deterministic arithmetic, never vibes.
+ *
+ * Builder pages plug in through `saddle_verify_builder_findings` (structural
+ * + echo, Saddle Pro's Divi driver) and the existing `saddle_lint_accessor`
+ * filter (judgment) — same one-tool-surface pattern as lint and render.
+ */
+class Saddle_Verify {
+
+	/**
+	 * Hard cap on returned findings; the rest is an overflow count.
+	 */
+	const FINDINGS_CAP = 40;
+
+	/**
+	 * Score penalties per finding, by source (lint splits by severity).
+	 */
+	const PENALTY_STRUCTURAL = 25;
+	const PENALTY_ECHO       = 10;
+	const PENALTY_LINT_ERROR = 8;
+	const PENALTY_LINT_WARN  = 3;
+
+	/**
+	 * Verify a post's persisted state.
+	 *
+	 * @param WP_Post                   $post     The post (freshly read by the caller).
+	 * @param string|null               $builder  Detected builder, null = native.
+	 * @param Saddle_Lint_Accessor|null $accessor Lint accessor, null = no judgment pass.
+	 * @return array { score, grade, counts, findings, overflow, skipped }
+	 */
+	public static function run( WP_Post $post, $builder, $accessor ) {
+		$tree     = Saddle_Tree::parse( $post->post_content );
+		$findings = array();
+		$skipped  = array();
+
+		// Pass 1 + 2 — structural + applied-vs-ignored, on persisted attrs.
+		if ( null === $builder ) {
+			$findings = array_merge( $findings, self::native_structural( $post, $tree ) );
+			$findings = array_merge( $findings, self::native_echo( $tree ) );
+		} else {
+			/**
+			 * Filter builder structural + echo findings for verify-page.
+			 *
+			 * Builder integrations (Saddle Pro's Divi driver) validate the
+			 * persisted tree and echo-check persisted attrs, returning
+			 * findings in the engine's shape: { address, source
+			 * (structural|echo), severity, message, fix_hint }. Null means
+			 * the builder has no verifier installed.
+			 *
+			 * @param array[]|null $findings Builder findings, null = unhandled.
+			 * @param array[]      $tree     Parsed persisted tree.
+			 * @param string       $builder  Detected builder.
+			 * @param WP_Post      $post     The post.
+			 */
+			$builder_findings = apply_filters( 'saddle_verify_builder_findings', null, $tree, $builder, $post );
+			if ( is_array( $builder_findings ) ) {
+				$findings = array_merge( $findings, $builder_findings );
+			} else {
+				$skipped[] = 'structural';
+				$skipped[] = 'echo';
+			}
+		}
+
+		// Pass 3 — judgment, through the same rules lint-page runs.
+		if ( $accessor instanceof Saddle_Lint_Accessor ) {
+			foreach ( Saddle_Lint::run( $tree, $accessor ) as $violation ) {
+				$findings[] = array(
+					'address'  => $violation['address'],
+					'source'   => 'lint',
+					'rule'     => $violation['rule'],
+					'severity' => $violation['severity'],
+					'message'  => $violation['message'],
+					'fix_hint' => $violation['fix_hint'],
+				);
+			}
+		} else {
+			$skipped[] = 'lint';
+		}
+
+		$findings = self::merge( $findings );
+		$score    = self::score( $findings );
+
+		$overflow = 0;
+		if ( count( $findings ) > self::FINDINGS_CAP ) {
+			$overflow = count( $findings ) - self::FINDINGS_CAP;
+			$findings = array_slice( $findings, 0, self::FINDINGS_CAP );
+		}
+
+		return array(
+			'score'    => $score,
+			'grade'    => self::grade( $score ),
+			'counts'   => self::counts( $findings, $overflow ),
+			'findings' => $findings,
+			'overflow' => $overflow,
+			'skipped'  => array_values( array_unique( $skipped ) ),
+		);
+	}
+
+	/*
+	---------------------------------------------------------------------
+	 * Native passes
+	 * -------------------------------------------------------------------
+	 */
+
+	/**
+	 * Structural check for native content: content that exists but parses to
+	 * no real blocks is a page the editor can't edit.
+	 *
+	 * @param WP_Post $post The post.
+	 * @param array[] $tree Parsed tree.
+	 * @return array[]
+	 */
+	private static function native_structural( WP_Post $post, array $tree ) {
+		if ( '' === trim( (string) $post->post_content ) ) {
+			return array();
+		}
+		foreach ( Saddle_Lint::nodes( $tree ) as $node ) {
+			if ( '' !== trim( (string) $node['type'] ) ) {
+				return array();
+			}
+		}
+		return array(
+			array(
+				'address'  => '',
+				'source'   => 'structural',
+				'severity' => 'error',
+				'message'  => __( 'The content is not block markup — the editor cannot address or edit it.', 'saddle' ),
+				'fix_hint' => __( 'Rebuild the content as blocks (set-blocks) instead of raw HTML.', 'saddle' ),
+			),
+		);
+	}
+
+	/**
+	 * Applied-vs-ignored on every persisted native node: attr paths core
+	 * will silently drop are designs that never took effect.
+	 *
+	 * @param array[] $tree Parsed tree.
+	 * @return array[]
+	 */
+	private static function native_echo( array $tree ) {
+		$findings = array();
+		foreach ( Saddle_Lint::nodes( $tree ) as $node ) {
+			$attrs = isset( $node['block']['attrs'] ) && is_array( $node['block']['attrs'] ) ? $node['block']['attrs'] : array();
+			if ( ! $attrs || '' === $node['type'] ) {
+				continue;
+			}
+			foreach ( Saddle_Blocks_Echo::check_attrs( $node['type'], $attrs, $node['address'] ) as $warning ) {
+				$findings[] = array(
+					'address'  => $node['address'],
+					'source'   => 'echo',
+					'severity' => 'error',
+					'message'  => (string) $warning,
+					'fix_hint' => __( 'This persisted attribute does nothing — rewrite it on a path the block actually supports, or remove it.', 'saddle' ),
+				);
+			}
+		}
+		return $findings;
+	}
+
+	/*
+	---------------------------------------------------------------------
+	 * Merge + score
+	 * -------------------------------------------------------------------
+	 */
+
+	/**
+	 * Dedupe and order findings: severity class first (structural, echo,
+	 * lint errors, lint warns), document order within each.
+	 *
+	 * @param array[] $findings Raw findings.
+	 * @return array[]
+	 */
+	private static function merge( array $findings ) {
+		$unique = array();
+		foreach ( $findings as $finding ) {
+			$key = implode(
+				'|',
+				array(
+					isset( $finding['address'] ) ? (string) $finding['address'] : '',
+					isset( $finding['source'] ) ? (string) $finding['source'] : '',
+					isset( $finding['rule'] ) ? (string) $finding['rule'] : md5( isset( $finding['message'] ) ? (string) $finding['message'] : '' ),
+				)
+			);
+			if ( ! isset( $unique[ $key ] ) ) {
+				$unique[ $key ] = $finding;
+			}
+		}
+		$findings = array_values( $unique );
+
+		usort(
+			$findings,
+			static function ( $a, $b ) {
+				$rank_a = self::rank( $a );
+				$rank_b = self::rank( $b );
+				if ( $rank_a !== $rank_b ) {
+					return $rank_a < $rank_b ? -1 : 1;
+				}
+				return Saddle_Lint::compare_addresses( $a, $b );
+			}
+		);
+		return $findings;
+	}
+
+	/**
+	 * Ordering rank of a finding: what an agent should fix first.
+	 *
+	 * @param array $finding The finding.
+	 * @return int
+	 */
+	private static function rank( array $finding ) {
+		if ( 'structural' === $finding['source'] ) {
+			return 0;
+		}
+		if ( 'echo' === $finding['source'] ) {
+			return 1;
+		}
+		return 'error' === $finding['severity'] ? 2 : 3;
+	}
+
+	/**
+	 * Deterministic 0–100 score.
+	 *
+	 * @param array[] $findings Deduped findings (pre-cap).
+	 * @return int
+	 */
+	private static function score( array $findings ) {
+		$score = 100;
+		foreach ( $findings as $finding ) {
+			switch ( self::rank( $finding ) ) {
+				case 0:
+					$score -= self::PENALTY_STRUCTURAL;
+					break;
+				case 1:
+					$score -= self::PENALTY_ECHO;
+					break;
+				case 2:
+					$score -= self::PENALTY_LINT_ERROR;
+					break;
+				default:
+					$score -= self::PENALTY_LINT_WARN;
+			}
+		}
+		return max( 0, $score );
+	}
+
+	/**
+	 * Letter grade for a score.
+	 *
+	 * @param int $score The score.
+	 * @return string
+	 */
+	private static function grade( $score ) {
+		if ( $score >= 90 ) {
+			return 'A';
+		}
+		if ( $score >= 75 ) {
+			return 'B';
+		}
+		if ( $score >= 60 ) {
+			return 'C';
+		}
+		if ( $score >= 40 ) {
+			return 'D';
+		}
+		return 'F';
+	}
+
+	/**
+	 * Finding counts by class, for the summary line.
+	 *
+	 * @param array[] $findings Capped findings.
+	 * @param int     $overflow Findings beyond the cap.
+	 * @return array
+	 */
+	private static function counts( array $findings, $overflow ) {
+		$counts = array(
+			'structural' => 0,
+			'ignored'    => 0,
+			'errors'     => 0,
+			'warnings'   => 0,
+		);
+		foreach ( $findings as $finding ) {
+			switch ( self::rank( $finding ) ) {
+				case 0:
+					++$counts['structural'];
+					break;
+				case 1:
+					++$counts['ignored'];
+					break;
+				case 2:
+					++$counts['errors'];
+					break;
+				default:
+					++$counts['warnings'];
+			}
+		}
+		$counts['overflow'] = (int) $overflow;
+		return $counts;
+	}
+}

--- a/saddle.php
+++ b/saddle.php
@@ -56,6 +56,7 @@ require_once SADDLE_DIR . 'includes/render/interface-saddle-render-accessor.php'
 require_once SADDLE_DIR . 'includes/render/class-saddle-render.php';
 require_once SADDLE_DIR . 'includes/render/class-saddle-render-gutenberg-accessor.php';
 require_once SADDLE_DIR . 'includes/preview/class-saddle-preview.php';
+require_once SADDLE_DIR . 'includes/verify/class-saddle-verify.php';
 require_once SADDLE_DIR . 'includes/class-saddle-capabilities.php';
 require_once SADDLE_DIR . 'includes/class-saddle-approval.php';
 require_once SADDLE_DIR . 'includes/class-saddle-context.php';
@@ -118,6 +119,7 @@ final class Saddle {
 			require_once SADDLE_DIR . 'includes/abilities/context.php';
 			require_once SADDLE_DIR . 'includes/abilities/lint.php';
 			require_once SADDLE_DIR . 'includes/abilities/render.php';
+			require_once SADDLE_DIR . 'includes/abilities/verify.php';
 			require_once SADDLE_DIR . 'includes/abilities/memory.php';
 			add_action( 'wp_abilities_api_categories_init', 'saddle_register_ability_category' );
 			add_action( 'wp_abilities_api_init', 'saddle_register_abilities' );
@@ -127,6 +129,7 @@ final class Saddle {
 			add_action( 'wp_abilities_api_init', 'saddle_register_context_abilities' );
 			add_action( 'wp_abilities_api_init', 'saddle_register_lint_abilities' );
 			add_action( 'wp_abilities_api_init', 'saddle_register_render_abilities' );
+			add_action( 'wp_abilities_api_init', 'saddle_register_verify_abilities' );
 			add_action( 'wp_abilities_api_init', 'saddle_register_memory_abilities' );
 			// First-party integration wrappers run late (30) so the partner
 			// plugins' own abilities exist to discover.

--- a/tests/verify-test.php
+++ b/tests/verify-test.php
@@ -1,0 +1,197 @@
+<?php
+/**
+ * The verify engine + the saddle/verify-page ability.
+ *
+ * Pins the closed loop (https://github.com/plugpressco/saddle/issues/26):
+ * findings from all three passes land at real dot addresses, the score is
+ * deterministic arithmetic, fixing the flagged addresses raises it back to
+ * 100 (the loop actually closes), payloads stay bounded, and builder pages
+ * resolve through the two filters exactly like lint.
+ *
+ * @package Saddle
+ */
+
+class Saddle_Verify_Test extends WP_UnitTestCase {
+
+	private $admin;
+
+	public function set_up() {
+		parent::set_up();
+		$this->admin = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $this->admin );
+	}
+
+	public function tear_down() {
+		remove_all_filters( 'saddle_verify_builder_findings' );
+		remove_all_filters( 'saddle_lint_accessor' );
+		parent::tear_down();
+	}
+
+	/* -------- helpers -------- */
+
+	private function page( $content ) {
+		return self::factory()->post->create(
+			array(
+				'post_type'    => 'page',
+				'post_content' => $content,
+			)
+		);
+	}
+
+	private function verify( $post_id ) {
+		$ability = wp_get_ability( 'saddle/verify-page' );
+		$this->assertNotNull( $ability, 'saddle/verify-page must be registered.' );
+		return $ability->execute( array( 'post_id' => $post_id ) );
+	}
+
+	private function bad_markup() {
+		// One echo problem (unknown style group -> silently no CSS) and one
+		// lint problem (button below WCAG AA).
+		return '<!-- wp:paragraph {"style":{"nonsense":{"x":1}}} --><p>Styled into the void.</p><!-- /wp:paragraph -->'
+			. '<!-- wp:button {"style":{"color":{"background":"#f5f5f5","text":"#ffffff"}}} --><div class="wp-block-button"><a class="wp-block-button__link wp-element-button">Go</a></div><!-- /wp:button -->';
+	}
+
+	private function clean_markup() {
+		return '<!-- wp:paragraph --><p>Honest copy.</p><!-- /wp:paragraph -->'
+			. '<!-- wp:button {"style":{"color":{"background":"#0a6b3d","text":"#ffffff"}}} --><div class="wp-block-button"><a class="wp-block-button__link wp-element-button">Go</a></div><!-- /wp:button -->';
+	}
+
+	/* -------- the clean case -------- */
+
+	public function test_clean_page_scores_100() {
+		$result = $this->verify( $this->page( $this->clean_markup() ) );
+
+		$this->assertNotWPError( $result );
+		$this->assertSame( 100, $result['score'] );
+		$this->assertSame( 'A', $result['grade'] );
+		$this->assertSame( array(), $result['findings'] );
+		$this->assertSame( array(), $result['skipped'] );
+	}
+
+	/* -------- findings from every pass, deterministic score -------- */
+
+	public function test_echo_and_lint_findings_land_at_addresses_with_arithmetic_score() {
+		$result = $this->verify( $this->page( $this->bad_markup() ) );
+
+		$this->assertNotWPError( $result );
+		// 100 - 10 (echo) - 8 (lint error) = 82.
+		$this->assertSame( 82, $result['score'] );
+		$this->assertSame( 'B', $result['grade'] );
+		$this->assertSame( 1, $result['counts']['ignored'] );
+		$this->assertSame( 1, $result['counts']['errors'] );
+
+		// Echo outranks lint — that styling never took effect at all.
+		$this->assertSame( 'echo', $result['findings'][0]['source'] );
+		$this->assertSame( '0', $result['findings'][0]['address'] );
+		$this->assertSame( 'lint', $result['findings'][1]['source'] );
+		$this->assertSame( '1', $result['findings'][1]['address'] );
+		$this->assertSame( 'button-contrast', $result['findings'][1]['rule'] );
+		$this->assertNotSame( '', $result['findings'][1]['fix_hint'] );
+	}
+
+	public function test_the_loop_closes_fixing_flagged_addresses_raises_the_score() {
+		$id     = $this->page( $this->bad_markup() );
+		$before = $this->verify( $id );
+		$this->assertSame( 82, $before['score'] );
+
+		// Fix exactly what was flagged, the way an agent would.
+		wp_update_post(
+			array(
+				'ID'           => $id,
+				'post_content' => $this->clean_markup(),
+			)
+		);
+
+		$after = $this->verify( $id );
+		$this->assertSame( 100, $after['score'], 'Verify re-reads persisted state — the fix must be visible immediately.' );
+		$this->assertSame( array(), $after['findings'] );
+	}
+
+	/* -------- structural -------- */
+
+	public function test_raw_html_content_is_a_structural_finding() {
+		$result = $this->verify( $this->page( '<div class="hand-rolled"><p>Not blocks at all.</p></div>' ) );
+
+		$this->assertSame( 1, $result['counts']['structural'] );
+		$this->assertSame( 'structural', $result['findings'][0]['source'] );
+		$this->assertSame( 75, $result['score'] ); // 100 - 25.
+	}
+
+	/* -------- bounded payload -------- */
+
+	public function test_findings_are_capped_with_an_overflow_count() {
+		$markup = '';
+		for ( $i = 0; $i < 45; $i++ ) {
+			$markup .= '<!-- wp:paragraph {"style":{"nonsense":{"x":1}}} --><p>N' . $i . '</p><!-- /wp:paragraph -->';
+		}
+		$result = $this->verify( $this->page( $markup ) );
+
+		$this->assertCount( Saddle_Verify::FINDINGS_CAP, $result['findings'] );
+		$this->assertSame( 5, $result['overflow'] );
+		$this->assertSame( 0, $result['score'], 'The score reflects ALL findings, not just the shown page.' );
+	}
+
+	/* -------- builder resolution -------- */
+
+	public function test_builder_page_with_no_verifier_is_refused() {
+		$id     = $this->page( '<!-- wp:divi/placeholder --><!-- wp:divi/section --><!-- /wp:divi/section --><!-- /wp:divi/placeholder -->' );
+		$result = $this->verify( $id );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'saddle_verify_unsupported', $result->get_error_code() );
+	}
+
+	public function test_builder_findings_and_accessor_arrive_through_the_filters() {
+		add_filter(
+			'saddle_verify_builder_findings',
+			static function ( $findings, $tree, $builder ) {
+				if ( 'Divi 5' !== $builder ) {
+					return $findings;
+				}
+				$finding = array(
+					'address'  => '0.0',
+					'source'   => 'echo',
+					'severity' => 'error',
+					'message'  => 'decoration.padding is not a group.',
+					'fix_hint' => 'Use decoration.spacing.',
+				);
+				// Returned twice on purpose — the engine must dedupe.
+				return array( $finding, $finding );
+			},
+			10,
+			3
+		);
+		add_filter(
+			'saddle_lint_accessor',
+			static function ( $accessor, $builder ) {
+				return 'Divi 5' === $builder ? new Saddle_Lint_Gutenberg_Accessor() : $accessor;
+			},
+			10,
+			2
+		);
+
+		$id     = $this->page( '<!-- wp:divi/placeholder --><!-- wp:divi/section --><!-- /wp:divi/section --><!-- /wp:divi/placeholder -->' );
+		$result = $this->verify( $id );
+
+		$this->assertNotWPError( $result );
+		$this->assertSame( 'Divi 5', $result['builder'] );
+		$this->assertSame( array(), $result['skipped'] );
+		$this->assertCount( 1, $result['findings'], 'Identical builder findings dedupe to one.' );
+		$this->assertSame( 90, $result['score'] ); // 100 - 10, deduped.
+	}
+
+	/* -------- registration -------- */
+
+	public function test_verify_page_is_read_tier_and_readonly() {
+		$meta = wp_get_ability( 'saddle/verify-page' )->get_meta();
+		$this->assertSame( 'read', $meta['saddle']['tier'] );
+		$this->assertTrue( $meta['annotations']['readonly'] );
+		$this->assertFalse( $meta['annotations']['destructive'] );
+	}
+
+	public function test_missing_post_is_not_found() {
+		$result = $this->verify( 999999 );
+		$this->assertWPError( $result );
+		$this->assertSame( 'saddle_not_found', $result->get_error_code() );
+	}
+}


### PR DESCRIPTION
Closes #26 — Pillar 2 ([epic #22](https://github.com/plugpressco/saddle/issues/22), build step F4). This completes the free half of the closed loop: **build → verify → fix by address → re-verify**.

## What

One scored answer to *"did what I built actually land, and is it any good?"*

- **`Saddle_Verify`** — three passes over **freshly re-read persisted state** (proving the database, not a write call's claim): structural → echo (persisted attrs the builder silently ignores — the design never took effect) → lint (judgment rules incl. the F5 a11y set). Findings dedupe, sort severity-then-document-order, cap at 40 + overflow count, and every one is keyed by the same dot address the page-read tools emit. Score is deterministic arithmetic (−25 structural / −10 ignored / −8 error / −3 warn, A–F bands) — never vibes.
- **`saddle/verify-page`** (read tier) — native pages run all three passes in free; builder pages plug structural+echo through the new **`saddle_verify_builder_findings`** filter and judgment through the existing `saddle_lint_accessor` filter — ready for Pro's Divi driver (saddle-pro#9). A builder page where nothing could run returns a clean unsupported error, never an empty "all good".
- `Saddle_Lint::compare_addresses` → public (verify reuses lint's ordering).

## Tests

9 tests — clean page = 100/A, echo+lint arithmetic (82 = 100−10−8) with echo outranking lint, **the loop closes** (fix the flagged addresses → score returns to 100), raw-HTML structural finding, cap+overflow with the score reflecting *all* findings, builder refusal, builder-filter path with dedupe, tier meta.

Free **300 green** (+9) · Pro **119 green** · phpcs clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)