### PR TITLE
Security: SSRF fail-closed (#38) + pin the execute() permission contract (#39)

### DIFF
--- a/includes/abilities/core-content.php
+++ b/includes/abilities/core-content.php
@@ -934,13 +934,16 @@ class Saddle_Abilities {
 			}
 		}
 
-		// If PHP can't resolve the host (some hosts disable dns_get_record /
-		// gethostbyname even when HTTP fetches still work), fail OPEN rather than
-		// break every legitimate upload. The literal-IP path above already blocks
-		// the primary metadata SSRF (e.g. http://169.254.169.254/), and
-		// wp_http_validate_url() plus download_url()'s redirect re-validation
-		// still apply. The residual DNS-rebinding TOCTOU is acknowledged.
-		$safe = true;
+		// Fail CLOSED when the host resolved to nothing. If PHP can't resolve the
+		// host (some locked-down hosts disable dns_get_record / gethostbyname even
+		// where HTTP fetches still work) we can't prove the target is external, so
+		// we refuse rather than let an unverifiable name through — an internal
+		// name that only resolves at fetch time would otherwise slip past this
+		// pre-flight. A trusted/NAT'd environment that legitimately can't resolve
+		// here can allow the source via the `saddle_source_url_is_safe` filter
+		// below (the WP_Error returned to the agent names that escape hatch). The
+		// residual DNS-rebinding TOCTOU on names that DO resolve is acknowledged.
+		$safe = ! empty( $ips );
 		foreach ( $ips as $ip ) {
 			if ( ! filter_var( $ip, FILTER_VALIDATE_IP, FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE ) ) {
 				$safe = false;
@@ -1280,7 +1283,7 @@ class Saddle_Abilities {
 
 		$url = esc_url_raw( trim( $input['source_url'] ) );
 		if ( ! wp_http_validate_url( $url ) || ! self::source_url_is_safe( $url ) ) {
-			return new WP_Error( 'saddle_invalid_source_url', __( 'The "source_url" is not a valid, fetchable URL, or it resolves to a disallowed internal address.', 'saddle' ), array( 'status' => 400 ) );
+			return new WP_Error( 'saddle_invalid_source_url', __( 'The "source_url" is not a valid, fetchable URL, or it resolves to a disallowed internal address. If the host is external but cannot be resolved on this server, the site owner can allow it via the "saddle_source_url_is_safe" filter.', 'saddle' ), array( 'status' => 400 ) );
 		}
 
 		// If attaching to a post, require permission to edit that post.

--- a/includes/class-saddle-mcp.php
+++ b/includes/class-saddle-mcp.php
@@ -386,9 +386,10 @@ class Saddle_MCP {
 		// Per the Abilities API contract, WP_Ability::execute() normalizes and
 		// validates input, runs the permission_callback, and returns WP_Error on
 		// denial or failure before invoking the execute_callback — so no separate
-		// permission pre-check is needed here. (Build Guide Step 1 calls for
-		// confirming this against the installed 6.9 core; the contract is
-		// documented, but verify on first boot).
+		// permission pre-check is needed here. Verified against WP 6.9 core
+		// (class-wp-ability.php: execute() calls check_permissions() first and
+		// short-circuits unless it returns true) and pinned by
+		// Saddle_MCP_Transport_Test::test_tools_call_enforces_tier_before_executing().
 		$outcome = $ability->execute( $arguments );
 
 		if ( is_wp_error( $outcome ) ) {

--- a/tests/mcp-transport-test.php
+++ b/tests/mcp-transport-test.php
@@ -56,4 +56,90 @@ class Saddle_MCP_Transport_Test extends WP_UnitTestCase {
 		// The instructions reuse Saddle_Context, which always names the scope.
 		$this->assertStringContainsString( 'posts', strtolower( $result['instructions'] ) );
 	}
+
+	/**
+	 * Drive a tools/call through the built-in JSON-RPC transport and return the
+	 * decoded JSON-RPC envelope (result or error).
+	 *
+	 * @param string $tool_name Full ability id, e.g. 'saddle/create-post'.
+	 * @param array  $arguments Tool arguments.
+	 * @return array Decoded JSON-RPC response.
+	 */
+	private function call_tool( $tool_name, array $arguments = array() ) {
+		$req = new WP_REST_Request( 'POST', '/saddle/v1/mcp' );
+		$req->set_header( 'content-type', 'application/json' );
+		$req->set_body(
+			wp_json_encode(
+				array(
+					'jsonrpc' => '2.0',
+					'id'      => 7,
+					'method'  => 'tools/call',
+					'params'  => array(
+						'name'      => $tool_name,
+						'arguments' => $arguments,
+					),
+				)
+			)
+		);
+
+		return Saddle_MCP::handle( $req )->get_data();
+	}
+
+	/**
+	 * Regression pin for the permission contract the fallback transport relies
+	 * on: WP_Ability::execute() must run the permission_callback and return a
+	 * WP_Error BEFORE the execute_callback runs. If a core change ever broke
+	 * that, every tier/approval check behind this transport would silently
+	 * vanish — verified true on WP 6.9 core, and this test keeps it that way.
+	 *
+	 * A write-tier tool called while the site sits at the default `read` tier
+	 * (by an administrator, so capabilities are NOT the limiting factor) must be
+	 * refused, and must not create anything.
+	 */
+	public function test_tools_call_enforces_tier_before_executing() {
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'administrator' ) ) );
+		Saddle_Capabilities::set_tier( 'read' );
+
+		$before = (int) wp_count_posts( 'post' )->publish;
+
+		$response = $this->call_tool(
+			'saddle/create-post',
+			array(
+				'title'   => 'Should never be created',
+				'content' => 'Blocked by the read tier.',
+				'status'  => 'publish',
+			)
+		);
+
+		$this->assertArrayHasKey( 'error', $response, 'A tier-denied tool call must return a JSON-RPC error envelope.' );
+		$this->assertArrayNotHasKey( 'result', $response );
+
+		$after = (int) wp_count_posts( 'post' )->publish;
+		$this->assertSame( $before, $after, 'A denied tool call must not create a post — proving the permission gate ran before the execute callback.' );
+
+		wp_set_current_user( 0 );
+	}
+
+	/**
+	 * The same path succeeds once the tier permits it — proving the test drives
+	 * a real create through the transport, so the denial above is meaningful.
+	 */
+	public function test_tools_call_succeeds_when_tier_permits() {
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'administrator' ) ) );
+		Saddle_Capabilities::set_tier( 'write' );
+
+		$response = $this->call_tool(
+			'saddle/create-post',
+			array(
+				'title'   => 'Allowed at write tier',
+				'content' => 'Created through the fallback transport.',
+				'status'  => 'draft',
+			)
+		);
+
+		$this->assertArrayHasKey( 'result', $response, 'A permitted tool call must return a JSON-RPC result envelope.' );
+		$this->assertArrayNotHasKey( 'error', $response );
+
+		wp_set_current_user( 0 );
+	}
 }

--- a/tests/media-ssrf-test.php
+++ b/tests/media-ssrf-test.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * SSRF guard for saddle/upload-media: source_url_is_safe() must reject internal
+ * targets and — since #38 — fail CLOSED when the host resolves to nothing, with
+ * the `saddle_source_url_is_safe` filter as the trusted-environment escape hatch.
+ *
+ * These exercise the guard method directly (it is the unit #38 changed); the
+ * public upload_media() entry additionally runs core's wp_http_validate_url(),
+ * which is a separate gate the Saddle filter deliberately does not override.
+ * Cases use literal IPs and an RFC 6761 `.invalid` host so resolution is
+ * deterministic and no network is touched.
+ *
+ * @package Saddle
+ */
+
+class Saddle_Media_SSRF_Test extends WP_UnitTestCase {
+
+	private function is_safe( $url ) {
+		$method = new ReflectionMethod( 'Saddle_Abilities', 'source_url_is_safe' );
+		$method->setAccessible( true );
+		return (bool) $method->invoke( null, $url );
+	}
+
+	public function tear_down() {
+		remove_all_filters( 'saddle_source_url_is_safe' );
+		parent::tear_down();
+	}
+
+	public function test_link_local_metadata_ip_is_unsafe() {
+		$this->assertFalse( $this->is_safe( 'http://169.254.169.254/latest/meta-data/' ) );
+	}
+
+	public function test_private_range_ip_is_unsafe() {
+		$this->assertFalse( $this->is_safe( 'http://10.0.0.5/x.jpg' ) );
+	}
+
+	public function test_loopback_is_unsafe() {
+		$this->assertFalse( $this->is_safe( 'http://127.0.0.1/x.jpg' ) );
+	}
+
+	/**
+	 * The #38 fix: a host that resolves to no IPs (here an RFC 6761 `.invalid`
+	 * name that can never resolve) is now unsafe rather than waved through.
+	 */
+	public function test_unresolvable_host_fails_closed() {
+		$this->assertFalse( $this->is_safe( 'http://nonexistent.invalid/x.jpg' ) );
+	}
+
+	/**
+	 * The escape hatch: a trusted environment can allow an otherwise-refused
+	 * source (including the fail-closed unresolvable case) via the filter.
+	 */
+	public function test_filter_can_override_the_block() {
+		add_filter( 'saddle_source_url_is_safe', '__return_true' );
+		$this->assertTrue( $this->is_safe( 'http://nonexistent.invalid/x.jpg' ) );
+	}
+
+	/**
+	 * A public literal IP passes the internal-address guard.
+	 */
+	public function test_public_ip_is_safe() {
+		$this->assertTrue( $this->is_safe( 'http://93.184.216.34/x.jpg' ) );
+	}
+
+	/**
+	 * A missing host is unsafe.
+	 */
+	public function test_hostless_url_is_unsafe() {
+		$this->assertFalse( $this->is_safe( 'not-a-url' ) );
+	}
+}


### PR DESCRIPTION
Two independent hardening items from the 2026-07-12 audit.

**#38 — SSRF guard fails closed.** `source_url_is_safe()` treated a host that resolved to zero IPs as safe (fail-open). On hosts where PHP DNS lookups are disabled but HTTP fetches still work, an agent-supplied name that only resolves at fetch time could bypass the internal-address block. Now refuses when nothing resolved; the `saddle_source_url_is_safe` filter stays as the trusted-env escape hatch and the WP_Error names it. 7 tests (literal metadata/private/loopback IPs, unresolvable→closed, filter override, public IP passes).

**#39 — pin the permission contract.** The fallback JSON-RPC transport trusts `WP_Ability::execute()` to run the permission_callback first — verified true on WP 6.9 core, now pinned by a regression test (write-tier tool at read tier → JSON-RPC error + nothing created). Comment updated from 'verify on first boot'.

Suite 309 green (300 base + 9 new). Production PHP is WPCS-clean; tests are out of phpcs scope by config.

Closes #38
Closes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017iV29qbQ5jCicpuJ8JAtRx