### PR TITLE
docs: stop hard-coding the ability count (#41)

### DIFF
--- a/BUILD-GUIDE.md
+++ b/BUILD-GUIDE.md
@@ -41,7 +41,7 @@ curl -i -u "username:application_password" \
   -H "Accept: application/json, text/event-stream" \
   -d '{"jsonrpc":"2.0","id":0,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"smoke","version":"1"}}}'
 
-# 2. tools/list — expect all 19 tools (send the session id from step 1)
+# 2. tools/list — expect every registered saddle/ tool (send the session id from step 1)
 curl -u "username:application_password" \
   -X POST https://yoursite.test/wp-json/saddle/v1/mcp \
   -H "Content-Type: application/json" -H "Accept: application/json, text/event-stream" \

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,7 +73,8 @@ includes/
                                  full safety model applied on top; saddle_integrations filter)
   class-saddle-mcp.php        — MCP transport on the official WP\MCP Adapter, JSON-RPC fallback
   abilities/                  — core-content (23), blocks (11), site (9, admin-tier settings), context (3),
-                                 lint (1), memory (3) — 50 free abilities total
+                                 memory (3), render (2), users (2), lint (1), verify (1) — 55 free abilities
+                                 as of 0.10.0 (the Permissions UI is the authoritative live list)
   class-saddle-skills.php     — skills store (saddle_skill CPT), owner-installed .md playbooks
   class-saddle-memory.php     — agent memory store (saddle_memory CPT); trust split — agent entries are
                                  recall-only until owner-pinned, autoinject defaults OFF

--- a/includes/class-saddle-mcp.php
+++ b/includes/class-saddle-mcp.php
@@ -67,8 +67,8 @@ class Saddle_MCP {
 	 * Uses the same namespace/route as the built-in transport, so the endpoint
 	 * URL (/wp-json/saddle/v1/mcp) is identical whether the adapter is present or
 	 * not. Exposing our abilities as an explicit tool list (rather than relying
-	 * on the adapter's default discover/execute meta-tools) surfaces all 19
-	 * abilities as first-class MCP tools with their own schemas.
+	 * on the adapter's default discover/execute meta-tools) surfaces every
+	 * registered `saddle/` ability as a first-class MCP tool with its own schema.
 	 *
 	 * @param object $adapter The McpAdapter instance passed by the action.
 	 */


### PR DESCRIPTION
The MCP registration comment (`class-saddle-mcp.php`) and the BUILD-GUIDE smoke test said 'all 19 abilities/tools'; CLAUDE.md's breakdown said 50 (it omitted render, users, verify). Reworded the code/guide spots to 'every registered `saddle/` ability' and corrected CLAUDE.md to the real **55**, naming the Permissions UI as the authoritative live list.

Closes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017iV29qbQ5jCicpuJ8JAtRx