### PR TITLE
feat: unified get-design-system + shared design-numbers guidance (#5)

### DIFF
--- a/includes/abilities/blocks.php
+++ b/includes/abilities/blocks.php
@@ -95,6 +95,23 @@ function saddle_register_block_abilities() {
 	);
 
 	wp_register_ability(
+		'saddle/get-design-system',
+		array(
+			'label'               => __( 'Get design system', 'saddle' ),
+			'description'         => __( 'Returns this site\'s design system in ONE builder-agnostic shape — colors, fonts, font sizes, spacing, layout widths, plus builder-native design variables and module presets when a page builder is active. On a block theme it reads theme.json; on Divi (with Saddle Pro) it reads Divi\'s Global Data. Read this FIRST when designing a page, and use the returned slugs/ids instead of hardcoded values so everything you build inherits the real brand. Read-only.', 'saddle' ),
+			'category'            => 'saddle',
+			'input_schema'        => array(
+				'type'       => 'object',
+				'default'    => (object) array(),
+				'properties' => (object) array(),
+			),
+			'execute_callback'    => array( 'Saddle_Blocks_Abilities', 'get_design_system' ),
+			'permission_callback' => Saddle_Capabilities::permission( 'read', 'read', 'get-design-system' ),
+			'meta'                => saddle_ability_meta( true, false, true, 'read' ),
+		)
+	);
+
+	wp_register_ability(
 		'saddle/list-block-patterns',
 		array(
 			'label'               => __( 'List block patterns', 'saddle' ),
@@ -370,6 +387,15 @@ class Saddle_Blocks_Abilities {
 	 */
 	public static function get_design_tokens() {
 		return Saddle_Blocks_Schema::design_tokens();
+	}
+
+	/**
+	 * saddle/get-design-system — one builder-agnostic design-system shape.
+	 *
+	 * @return array
+	 */
+	public static function get_design_system() {
+		return Saddle_Blocks_Schema::design_system();
 	}
 
 	/**

--- a/includes/admin/class-saddle-rest.php
+++ b/includes/admin/class-saddle-rest.php
@@ -597,10 +597,11 @@ class Saddle_REST_Admin {
 	private static function category_for( $short, $name ) {
 		$rules = array(
 			// label => substrings (first hit wins).
+			'Design system'   => array( 'design-system', 'design-tokens', 'bootstrap-design' ),
 			'Divi'            => array( 'divi-' ),
 			'Integrations'    => array( 'waggle-', 'knovia-' ),
 			'Memory & skills' => array( 'remember', 'recall', 'forget', 'skill', 'instructions' ),
-			'Blocks & layout' => array( 'block', 'render-node', 'verify-page', 'lint-page', 'preview', 'design-tokens' ),
+			'Blocks & layout' => array( 'block', 'render-node', 'verify-page', 'lint-page', 'preview' ),
 			'Users'           => array( 'user' ),
 			'Site & settings' => array( 'option', 'plugin', 'theme', 'cache', 'site-info' ),
 			'Content'         => array( 'post', 'page', 'media', 'categor', 'tag', 'revision', 'search' ),

--- a/includes/class-saddle-blocks-schema.php
+++ b/includes/class-saddle-blocks-schema.php
@@ -408,6 +408,47 @@ class Saddle_Blocks_Schema {
 	}
 
 	/**
+	 * The unified, builder-agnostic design-system shape.
+	 *
+	 * Free Saddle fills it from theme.json (the Gutenberg/block-theme source);
+	 * a page-builder addon overrides `builder`/`source` and fills the
+	 * builder-native slots (colors, variables, presets, fonts) via the
+	 * `saddle_design_system` filter, so an agent gets ONE shape whatever the
+	 * site is built with. `variables`/`presets` are empty on a plain block
+	 * theme — they are builder concepts.
+	 *
+	 * @return array
+	 */
+	public static function design_system() {
+		$tokens = self::design_tokens();
+		$has_tj = ! isset( $tokens['note'] );
+
+		$shape = array(
+			'builder'    => wp_is_block_theme() ? 'block-theme' : 'classic',
+			'source'     => $has_tj ? 'theme.json' : 'none',
+			'colors'     => $has_tj ? $tokens['colors'] : array(),
+			'gradients'  => $has_tj ? $tokens['gradients'] : array(),
+			'font_sizes' => $has_tj ? $tokens['font_sizes'] : array(),
+			'fonts'      => $has_tj ? $tokens['font_families'] : array(),
+			'spacing'    => $has_tj ? $tokens['spacing_sizes'] : array(),
+			'layout'     => $has_tj ? $tokens['layout'] : array( 'content_width' => null, 'wide_width' => null ),
+			'variables'  => array(),
+			'presets'    => array(),
+			'usage'      => __( 'This is the site\'s single source of design truth — use it before building so pages inherit the real brand instead of inventing one. On a block theme, reference the color/size SLUGS in block attrs; on a page builder, use the color/variable IDs the builder addon lists here. Entries are listed theme/brand-first.', 'saddle' ),
+		);
+
+		/**
+		 * Filter the unified design system. A builder addon (e.g. Saddle Pro for
+		 * Divi) sets `builder`/`source` and fills `colors`/`variables`/`presets`/
+		 * `fonts` from the builder's own store, keeping one response shape across
+		 * builders.
+		 *
+		 * @param array $shape The theme.json-derived design system.
+		 */
+		return apply_filters( 'saddle_design_system', $shape );
+	}
+
+	/**
 	 * Flatten one preset list from theme.json settings, theme origin first.
 	 *
 	 * @param array    $settings Merged settings.

--- a/includes/class-saddle-context.php
+++ b/includes/class-saddle-context.php
@@ -113,8 +113,13 @@ class Saddle_Context {
 		$lines[] = __( '# Designing pages with blocks', 'saddle' );
 		$lines[] = '';
 		$lines[] = '- ' . __( 'For page layouts, use the structured block tools (get-blocks, set-blocks, add/edit/move/remove-block) instead of writing a raw "content" string — they compose real editor blocks that stay editable in the block editor, and every change is validated before it is saved.', 'saddle' );
-		$lines[] = '- ' . __( 'Match the site\'s design, don\'t invent one: read get-design-tokens first and use its preset slugs for colors, font sizes, and spacing. For common sections (hero, features, CTA), check list-block-patterns — inserting a theme-styled pattern beats hand-composing.', 'saddle' );
+		$lines[] = '- ' . __( 'Match the site\'s design, don\'t invent one: read get-design-system first (one shape for any builder) and use its color/size slugs or ids for colors, fonts, and spacing. For common sections (hero, features, CTA), check list-block-patterns — inserting a theme-styled pattern beats hand-composing.', 'saddle' );
 		$lines[] = '- ' . __( 'Before composing a block type you haven\'t used, read get-block-schema for its exact authoring syntax. Never fake a layout by dumping raw HTML into a single block.', 'saddle' );
+		$lines[] = '';
+
+		foreach ( self::design_numbers() as $line ) {
+			$lines[] = $line;
+		}
 		$lines[] = '';
 
 		// Content landscape — orient the agent to what exists, and name public
@@ -229,6 +234,26 @@ class Saddle_Context {
 		$lines[] = '';
 
 		return $lines;
+	}
+
+	/**
+	 * The shared "what good design means in numbers" section — builder-agnostic
+	 * hard numbers served to every agent (Gutenberg or a page builder), so the
+	 * design bar doesn't live only inside one builder's skill. A builder addon
+	 * can reuse these lines instead of restating them.
+	 *
+	 * @return string[] Markdown lines.
+	 */
+	public static function design_numbers() {
+		return array(
+			__( '# What "designed" means, in numbers', 'saddle' ),
+			'',
+			'- ' . __( 'Type scale: hero/display 44–64px, section headings 28–40px, body 16–18px with line-height 1.5–1.7. Establish a clear step between levels — don\'t set everything near the same size.', 'saddle' ),
+			'- ' . __( 'Line length: keep body text to ~50–75 characters per line (roughly a 600–720px max width for a text column), never full-bleed paragraphs.', 'saddle' ),
+			'- ' . __( 'Spacing on an 8px system (8/16/24/32/48/64/96): generous section padding (~64–96px top/bottom on desktop), consistent gaps within a group, and more space BETWEEN groups than inside them.', 'saddle' ),
+			'- ' . __( 'Color: one dominant neutral background, one text color, and a SINGLE accent used sparingly for emphasis and calls to action. Body text must hit WCAG AA contrast (≥ 4.5:1; ≥ 3:1 for large headings).', 'saddle' ),
+			'- ' . __( 'Rhythm: align to a consistent content width, reuse the same handful of spacing/size steps across the page, and prefer one strong idea per section over dense walls of content.', 'saddle' ),
+		);
 	}
 
 	/**


### PR DESCRIPTION
Two of the three #5 deliverables (the brief/bundle halves shipped in the epic).

- **`saddle/get-design-system`** — one builder-agnostic shape (colors, fonts, font sizes, spacing, layout + builder-native variables/presets). Reads theme.json on a block theme; a **`saddle_design_system` filter** lets Saddle Pro plug Divi Global Data through the *same* shape.
- **Shared hard-numbers design section** — `Saddle_Context::design_numbers()` (type scale, ~50–75ch line length, 8px spacing, single accent + WCAG AA, rhythm) now ships in the system context for **every** builder, not buried in one skill.
- New **Design system** Permissions category; guidance now points at get-design-system.

Live-verified on Divi 5.8.1 (with the Pro filter PR): returns real Global Data — 5 colors incl. `gcid-primary-color`, variables, unified keys. Free + Pro suites green (318 / 158).

Bootstrap-design-system (#5's third item) follows separately.

Part of #5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017iV29qbQ5jCicpuJ8JAtRx