### PR TITLE
feat: section recipes (list/get-section-recipe) (#6)

### DIFF
--- a/includes/abilities/blocks.php
+++ b/includes/abilities/blocks.php
@@ -125,6 +125,45 @@ function saddle_register_block_abilities() {
 	);
 
 	wp_register_ability(
+		'saddle/list-section-recipes',
+		array(
+			'label'               => __( 'List section recipes', 'saddle' ),
+			'description'         => __( 'Lists Saddle\'s built-in section recipes — ready-to-insert blueprints for common page sections (hero, features, pricing, testimonials, call-to-action, FAQ) — as {name, title, description}. Read-only. Get one with get-section-recipe, then insert it and swap in real copy and design tokens. Building from a recipe beats composing a section from scratch.', 'saddle' ),
+			'category'            => 'saddle',
+			'input_schema'        => array(
+				'type'       => 'object',
+				'default'    => (object) array(),
+				'properties' => (object) array(),
+			),
+			'execute_callback'    => array( 'Saddle_Blocks_Abilities', 'list_section_recipes' ),
+			'permission_callback' => Saddle_Capabilities::permission( 'read', 'read', 'list-section-recipes' ),
+			'meta'                => saddle_ability_meta( true, false, true, 'read' ),
+		)
+	);
+
+	wp_register_ability(
+		'saddle/get-section-recipe',
+		array(
+			'label'               => __( 'Get a section recipe', 'saddle' ),
+			'description'         => __( 'Returns one section recipe as a ready-to-insert node tree in Saddle\'s authoring format ({type, content, attrs, children}), matched to the site\'s builder — core blocks on a block theme, the builder\'s modules when a page builder is active. Read-only. Pass it (with real copy substituted) to set-blocks / add-block, or to the builder\'s set-page. After inserting, apply colors and sizes from get-design-system.', 'saddle' ),
+			'category'            => 'saddle',
+			'input_schema'        => array(
+				'type'       => 'object',
+				'required'   => array( 'name' ),
+				'properties' => array(
+					'name' => array(
+						'type'        => 'string',
+						'description' => __( 'Recipe name from list-section-recipes (e.g. "hero", "features", "pricing", "testimonials", "cta", "faq").', 'saddle' ),
+					),
+				),
+			),
+			'execute_callback'    => array( 'Saddle_Blocks_Abilities', 'get_section_recipe' ),
+			'permission_callback' => Saddle_Capabilities::permission( 'read', 'read', 'get-section-recipe' ),
+			'meta'                => saddle_ability_meta( true, false, true, 'read' ),
+		)
+	);
+
+	wp_register_ability(
 		'saddle/get-design-system',
 		array(
 			'label'               => __( 'Get design system', 'saddle' ),
@@ -426,6 +465,74 @@ class Saddle_Blocks_Abilities {
 	 */
 	public static function get_design_system() {
 		return Saddle_Blocks_Schema::design_system();
+	}
+
+	/**
+	 * saddle/list-section-recipes.
+	 *
+	 * @return array
+	 */
+	public static function list_section_recipes() {
+		$out = array();
+		foreach ( Saddle_Recipes::catalog() as $name => $meta ) {
+			$out[] = array(
+				'name'        => $name,
+				'title'       => $meta['title'],
+				'description' => $meta['description'],
+			);
+		}
+		return array(
+			'recipes' => $out,
+			'usage'   => __( 'Get one with get-section-recipe, substitute real copy, insert with set-blocks/add-block (or the builder\'s set-page), then apply colors and sizes from get-design-system.', 'saddle' ),
+		);
+	}
+
+	/**
+	 * saddle/get-section-recipe.
+	 *
+	 * @param array $input Ability input.
+	 * @return array|WP_Error
+	 */
+	public static function get_section_recipe( $input = null ) {
+		$name    = is_array( $input ) && isset( $input['name'] ) ? sanitize_key( (string) $input['name'] ) : '';
+		$catalog = Saddle_Recipes::catalog();
+		if ( '' === $name || ! isset( $catalog[ $name ] ) ) {
+			return new WP_Error(
+				'saddle_unknown_recipe',
+				sprintf(
+					/* translators: %s: comma-separated recipe names. */
+					__( 'Unknown recipe. Available: %s.', 'saddle' ),
+					implode( ', ', array_keys( $catalog ) )
+				),
+				array( 'status' => 400 )
+			);
+		}
+
+		$nodes   = Saddle_Recipes::gutenberg( $name );
+		$builder = 'block-theme';
+
+		/**
+		 * Let a page-builder addon supply its own node tree for a recipe name,
+		 * so the recipe vocabulary is shared across builders. Return
+		 * array( 'builder' => '<slug>', 'nodes' => array(...) ) to override.
+		 *
+		 * @param array|null $override Builder-specific recipe, or null.
+		 * @param string     $name     Recipe name.
+		 * @param array      $nodes    The default (Gutenberg) node tree.
+		 */
+		$override = apply_filters( 'saddle_section_recipe', null, $name, $nodes );
+		if ( is_array( $override ) && ! empty( $override['nodes'] ) ) {
+			$nodes   = $override['nodes'];
+			$builder = isset( $override['builder'] ) ? (string) $override['builder'] : 'custom';
+		}
+
+		return array(
+			'name'    => $name,
+			'title'   => $catalog[ $name ]['title'],
+			'builder' => $builder,
+			'nodes'   => $nodes,
+			'usage'   => __( 'Insert these nodes (with real copy) via set-blocks/add-block on a block theme, or the builder\'s set-page/add-module. The recipe is intentionally token-free — apply colors and sizes from get-design-system after inserting.', 'saddle' ),
+		);
 	}
 
 	/**

--- a/includes/admin/class-saddle-rest.php
+++ b/includes/admin/class-saddle-rest.php
@@ -601,7 +601,7 @@ class Saddle_REST_Admin {
 			'Divi'            => array( 'divi-' ),
 			'Integrations'    => array( 'waggle-', 'knovia-' ),
 			'Memory & skills' => array( 'remember', 'recall', 'forget', 'skill', 'instructions' ),
-			'Blocks & layout' => array( 'block', 'render-node', 'verify-page', 'lint-page', 'preview' ),
+			'Blocks & layout' => array( 'block', 'render-node', 'verify-page', 'lint-page', 'preview', 'recipe' ),
 			'Users'           => array( 'user' ),
 			'Site & settings' => array( 'option', 'plugin', 'theme', 'cache', 'site-info' ),
 			'Content'         => array( 'post', 'page', 'media', 'categor', 'tag', 'revision', 'search' ),

--- a/includes/class-saddle-recipes.php
+++ b/includes/class-saddle-recipes.php
@@ -1,0 +1,208 @@
+<?php
+/**
+ * Section recipes — curated, ready-to-insert blueprints for the common page
+ * sections (hero, features, pricing, testimonials, CTA, FAQ).
+ *
+ * A recipe is a node tree in Saddle's authoring format ({type, content, attrs,
+ * children}) with placeholder copy, so an agent inserts a well-structured
+ * section and then swaps in real content + design tokens (from
+ * get-design-system) instead of composing a layout from scratch. The free
+ * plugin ships the Gutenberg (core-block) bodies; a page-builder addon returns
+ * its own bodies for the same recipe names via the `saddle_section_recipe`
+ * filter, so the recipe vocabulary is the same across builders.
+ *
+ * Recipes stay design-token-agnostic on purpose: they carry structure + copy +
+ * heading levels, not site-specific color/size slugs (which would render as
+ * "unset" on a site that doesn't define them). The response tells the agent to
+ * apply tokens from get-design-system after inserting.
+ *
+ * @package Saddle
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Curated section-recipe catalog + Gutenberg bodies.
+ */
+class Saddle_Recipes {
+
+	/**
+	 * The recipe catalog: name => { title, description }.
+	 *
+	 * @return array<string, array{title:string, description:string}>
+	 */
+	public static function catalog() {
+		return array(
+			'hero'         => array(
+				'title'       => __( 'Hero', 'saddle' ),
+				'description' => __( 'A headline, a supporting line, and a primary + secondary call to action.', 'saddle' ),
+			),
+			'features'     => array(
+				'title'       => __( 'Features', 'saddle' ),
+				'description' => __( 'A section heading over a three-column grid of feature blurbs.', 'saddle' ),
+			),
+			'pricing'      => array(
+				'title'       => __( 'Pricing', 'saddle' ),
+				'description' => __( 'Three pricing tiers, each with a name, price, feature list, and button.', 'saddle' ),
+			),
+			'testimonials' => array(
+				'title'       => __( 'Testimonials', 'saddle' ),
+				'description' => __( 'A heading over three customer quotes with attributions.', 'saddle' ),
+			),
+			'cta'          => array(
+				'title'       => __( 'Call to action', 'saddle' ),
+				'description' => __( 'A closing banner: a short headline, a line of copy, and a button.', 'saddle' ),
+			),
+			'faq'          => array(
+				'title'       => __( 'FAQ', 'saddle' ),
+				'description' => __( 'A heading over a list of question/answer pairs.', 'saddle' ),
+			),
+		);
+	}
+
+	/**
+	 * The Gutenberg (core-block) node tree for a recipe, or null if unknown.
+	 *
+	 * @param string $name Recipe name.
+	 * @return array[]|null
+	 */
+	public static function gutenberg( $name ) {
+		switch ( $name ) {
+			case 'hero':
+				return array(
+					self::group(
+						array(
+							self::heading( __( 'A clear, benefit-led headline', 'saddle' ), 1 ),
+							self::paragraph( __( 'One supporting sentence that says who it is for and why it matters.', 'saddle' ) ),
+							self::buttons( array( __( 'Get started', 'saddle' ), __( 'Learn more', 'saddle' ) ) ),
+						)
+					),
+				);
+
+			case 'features':
+				return array(
+					self::heading( __( 'What you get', 'saddle' ), 2 ),
+					self::columns(
+						array(
+							self::feature_col( __( 'First benefit', 'saddle' ) ),
+							self::feature_col( __( 'Second benefit', 'saddle' ) ),
+							self::feature_col( __( 'Third benefit', 'saddle' ) ),
+						)
+					),
+				);
+
+			case 'pricing':
+				return array(
+					self::heading( __( 'Simple pricing', 'saddle' ), 2 ),
+					self::columns(
+						array(
+							self::price_col( __( 'Starter', 'saddle' ), __( '$0', 'saddle' ) ),
+							self::price_col( __( 'Pro', 'saddle' ), __( '$29', 'saddle' ) ),
+							self::price_col( __( 'Team', 'saddle' ), __( '$99', 'saddle' ) ),
+						)
+					),
+				);
+
+			case 'testimonials':
+				return array(
+					self::heading( __( 'What people say', 'saddle' ), 2 ),
+					self::columns(
+						array(
+							self::quote_col(),
+							self::quote_col(),
+							self::quote_col(),
+						)
+					),
+				);
+
+			case 'cta':
+				return array(
+					self::group(
+						array(
+							self::heading( __( 'Ready to start?', 'saddle' ), 2 ),
+							self::paragraph( __( 'A short line that removes the last bit of hesitation.', 'saddle' ) ),
+							self::buttons( array( __( 'Get started', 'saddle' ) ) ),
+						)
+					),
+				);
+
+			case 'faq':
+				return array(
+					self::heading( __( 'Frequently asked questions', 'saddle' ), 2 ),
+					self::heading( __( 'A common question?', 'saddle' ), 3 ),
+					self::paragraph( __( 'A clear, direct answer in one or two sentences.', 'saddle' ) ),
+					self::heading( __( 'Another common question?', 'saddle' ), 3 ),
+					self::paragraph( __( 'A clear, direct answer in one or two sentences.', 'saddle' ) ),
+					self::heading( __( 'A third common question?', 'saddle' ), 3 ),
+					self::paragraph( __( 'A clear, direct answer in one or two sentences.', 'saddle' ) ),
+				);
+		}
+
+		return null;
+	}
+
+	/* ---- small node builders (keep the recipes above readable) ---- */
+
+	private static function heading( $text, $level ) {
+		return array( 'type' => 'core/heading', 'content' => $text, 'attrs' => array( 'level' => $level ) );
+	}
+
+	private static function paragraph( $text ) {
+		return array( 'type' => 'core/paragraph', 'content' => $text );
+	}
+
+	private static function buttons( array $labels ) {
+		$buttons = array();
+		foreach ( $labels as $label ) {
+			$buttons[] = array( 'type' => 'core/button', 'content' => $label, 'attrs' => array( 'url' => '#' ) );
+		}
+		return array( 'type' => 'core/buttons', 'children' => $buttons );
+	}
+
+	private static function group( array $children ) {
+		return array( 'type' => 'core/group', 'children' => $children );
+	}
+
+	private static function columns( array $columns ) {
+		return array( 'type' => 'core/columns', 'children' => $columns );
+	}
+
+	private static function feature_col( $title ) {
+		return array(
+			'type'     => 'core/column',
+			'children' => array(
+				self::heading( $title, 3 ),
+				self::paragraph( __( 'One or two sentences describing this benefit in plain language.', 'saddle' ) ),
+			),
+		);
+	}
+
+	private static function price_col( $plan, $price ) {
+		return array(
+			'type'     => 'core/column',
+			'children' => array(
+				self::heading( $plan, 3 ),
+				self::paragraph( $price ),
+				array(
+					'type'     => 'core/list',
+					'children' => array(
+						array( 'type' => 'core/list-item', 'content' => __( 'What this plan includes', 'saddle' ) ),
+						array( 'type' => 'core/list-item', 'content' => __( 'A second included item', 'saddle' ) ),
+						array( 'type' => 'core/list-item', 'content' => __( 'A third included item', 'saddle' ) ),
+					),
+				),
+				self::buttons( array( __( 'Choose plan', 'saddle' ) ) ),
+			),
+		);
+	}
+
+	private static function quote_col() {
+		return array(
+			'type'     => 'core/column',
+			'children' => array(
+				self::paragraph( __( '"A specific, believable sentence about the result they got."', 'saddle' ) ),
+				self::paragraph( __( '— Name, Role', 'saddle' ) ),
+			),
+		);
+	}
+}

--- a/saddle.php
+++ b/saddle.php
@@ -34,6 +34,7 @@ require_once SADDLE_DIR . 'includes/class-saddle-tree.php';
 require_once SADDLE_DIR . 'includes/class-saddle-blocks-tree.php';
 require_once SADDLE_DIR . 'includes/class-saddle-blocks-author.php';
 require_once SADDLE_DIR . 'includes/class-saddle-blocks-schema.php';
+require_once SADDLE_DIR . 'includes/class-saddle-recipes.php';
 require_once SADDLE_DIR . 'includes/class-saddle-blocks-echo.php';
 require_once SADDLE_DIR . 'includes/lint/interface-saddle-lint-accessor.php';
 require_once SADDLE_DIR . 'includes/lint/interface-saddle-lint-style-accessor.php';

--- a/tests/blocks-test.php
+++ b/tests/blocks-test.php
@@ -406,6 +406,48 @@ class Saddle_Blocks_Test extends WP_UnitTestCase {
 		$this->assertSame( 'gcid-x', $ds['colors'][0]['id'] );
 	}
 
+	public function test_section_recipes_list_and_apply_cleanly() {
+		$list = $this->run_ability( 'list-section-recipes' );
+		$this->assertNotWPError( $list );
+		$names = wp_list_pluck( $list['recipes'], 'name' );
+		$this->assertSame(
+			array( 'hero', 'features', 'pricing', 'testimonials', 'cta', 'faq' ),
+			$names
+		);
+
+		// Every recipe's node tree must apply through set-blocks without warnings.
+		foreach ( $names as $name ) {
+			$recipe = $this->run_ability( 'get-section-recipe', array( 'name' => $name ) );
+			$this->assertNotWPError( $recipe, "get-section-recipe {$name}" );
+			$this->assertNotEmpty( $recipe['nodes'], "{$name} has nodes" );
+
+			$id  = $this->page( '<!-- wp:paragraph --><p>seed</p><!-- /wp:paragraph -->' );
+			$set = $this->run_ability( 'set-blocks', array( 'post_id' => $id, 'nodes' => $recipe['nodes'] ) );
+			$this->assertNotWPError( $set, "set-blocks {$name}" );
+			$this->assertArrayNotHasKey( 'warnings', $set, "{$name} inserts without applied-vs-ignored warnings" );
+		}
+	}
+
+	public function test_unknown_section_recipe_errors() {
+		$r = $this->run_ability( 'get-section-recipe', array( 'name' => 'nope' ) );
+		$this->assertWPError( $r );
+		$this->assertSame( 'saddle_unknown_recipe', $r->get_error_code() );
+	}
+
+	public function test_section_recipe_filter_lets_a_builder_override() {
+		add_filter(
+			'saddle_section_recipe',
+			static function () {
+				return array( 'builder' => 'divi', 'nodes' => array( array( 'type' => 'divi/section' ) ) );
+			}
+		);
+		$r = $this->run_ability( 'get-section-recipe', array( 'name' => 'hero' ) );
+		remove_all_filters( 'saddle_section_recipe' );
+
+		$this->assertSame( 'divi', $r['builder'] );
+		$this->assertSame( 'divi/section', $r['nodes'][0]['type'] );
+	}
+
 	public function test_bootstrap_design_system_gates_before_writing() {
 		Saddle_Capabilities::set_tier( 'admin' );
 


### PR DESCRIPTION
Curated, ready-to-insert blueprints for the six common sections — **hero, features, pricing, testimonials, CTA, FAQ**.

- `list-section-recipes` → the catalog; `get-section-recipe` → one as an authoring node tree matched to the builder (core blocks by default; a `saddle_section_recipe` filter lets Saddle Pro return Divi trees for the same names).
- Recipes are **token-free by design** (structure + placeholder copy), so they apply cleanly on any site; the agent layers real content + get-design-system tokens after.

Live-verified on Divi 5.8.1: all 6 apply through set-blocks with **zero warnings, verify-page 97–100**. +3 tests; suite 324 green.

Part of #6 — the Divi recipe bodies land via the filter in a Pro PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017iV29qbQ5jCicpuJ8JAtRx