### PR TITLE
Phase 2: security hardening — token user-binding, credential marker, log caps, domain enforcement

### DIFF
--- a/includes/admin/class-saddle-rest.php
+++ b/includes/admin/class-saddle-rest.php
@@ -343,6 +343,7 @@ class Saddle_REST_Admin {
 				'domain'         => array(
 					'current'  => Saddle_Capabilities::current_domain(),
 					'recorded' => Saddle_Capabilities::recorded_tier_domain(),
+					'enforced' => Saddle_Capabilities::is_domain_enforced(),
 				),
 				// The key itself never leaves the server — only whether one is
 				// set, plus a last-4 hint so the owner can recognize it.
@@ -390,6 +391,10 @@ class Saddle_REST_Admin {
 
 		if ( array_key_exists( 'paused', $params ) ) {
 			Saddle_Capabilities::set_paused( (bool) $request->get_param( 'paused' ) );
+		}
+
+		if ( array_key_exists( 'domain_enforced', $params ) ) {
+			Saddle_Capabilities::set_domain_enforcement( (bool) $request->get_param( 'domain_enforced' ) );
 		}
 
 		// Key absent from the body ⇒ untouched; '' or null ⇒ cleared;
@@ -814,6 +819,10 @@ class Saddle_REST_Admin {
 		$hints[ $item['uuid'] ] = $hint;
 		update_user_meta( $user->ID, 'saddle_client_hints', $hints );
 
+		// The immutable ownership marker credential scoping keys on — the
+		// display name alone is user-editable and can't be trusted for it.
+		Saddle_Connection::mark_issued( $user->ID, $item['uuid'] );
+
 		return new WP_REST_Response(
 			array(
 				'uuid'       => $item['uuid'],
@@ -843,13 +852,15 @@ class Saddle_REST_Admin {
 
 			$passwords = WP_Application_Passwords::get_user_application_passwords( $user_id );
 			foreach ( (array) $passwords as $item ) {
-				if ( empty( $item['name'] ) || 0 !== strpos( $item['name'], self::CLIENT_PREFIX ) ) {
+				// Marker first (rename-proof), name prefix for legacy keys.
+				if ( empty( $item['uuid'] ) || ! Saddle_Connection::is_saddle_issued( $user_id, $item['uuid'] ) ) {
 					continue;
 				}
+				$name = isset( $item['name'] ) ? (string) $item['name'] : '';
 				$clients[] = array(
 					'uuid'      => $item['uuid'],
-					'name'      => $item['name'],
-					'label'     => trim( substr( $item['name'], strlen( self::CLIENT_PREFIX ) ) ),
+					'name'      => $name,
+					'label'     => 0 === strpos( $name, self::CLIENT_PREFIX ) ? trim( substr( $name, strlen( self::CLIENT_PREFIX ) ) ) : $name,
 					'created'   => isset( $item['created'] ) ? (int) $item['created'] : 0,
 					'last_used' => isset( $item['last_used'] ) ? $item['last_used'] : null,
 					'last_ip'   => isset( $item['last_ip'] ) ? $item['last_ip'] : null,
@@ -877,10 +888,12 @@ class Saddle_REST_Admin {
 			return new WP_Error( 'saddle_app_passwords_unavailable', __( 'Application Passwords are not available on this site.', 'saddle' ), array( 'status' => 500 ) );
 		}
 
-		// Only allow revoking a Saddle-prefixed password, so this endpoint can't
-		// be used to delete unrelated credentials.
+		// Only allow revoking a Saddle-issued password, so this endpoint can't
+		// be used to delete unrelated credentials. Checked via the immutable
+		// marker (with legacy name-prefix fallback), so a renamed key can
+		// still be revoked here.
 		$item = WP_Application_Passwords::get_user_application_password( $user_id, $uuid );
-		if ( ! $item || empty( $item['name'] ) || 0 !== strpos( $item['name'], self::CLIENT_PREFIX ) ) {
+		if ( ! $item || ! Saddle_Connection::is_saddle_issued( $user_id, $uuid ) ) {
 			return new WP_Error( 'saddle_client_not_found', __( 'No Saddle client with that ID.', 'saddle' ), array( 'status' => 404 ) );
 		}
 
@@ -888,6 +901,7 @@ class Saddle_REST_Admin {
 		if ( is_wp_error( $result ) ) {
 			return $result;
 		}
+		Saddle_Connection::unmark_issued( $user_id, $uuid );
 
 		// Drop the stored last-4 hint along with the credential.
 		$hints = get_user_meta( $user_id, 'saddle_client_hints', true );
@@ -931,7 +945,7 @@ class Saddle_REST_Admin {
 
 		// Same guard as revoke_client: only Saddle-issued credentials.
 		$item = WP_Application_Passwords::get_user_application_password( $user->ID, $uuid );
-		if ( ! $item || empty( $item['name'] ) || 0 !== strpos( $item['name'], self::CLIENT_PREFIX ) ) {
+		if ( ! $item || ! Saddle_Connection::is_saddle_issued( $user->ID, $uuid ) ) {
 			return new WP_Error( 'saddle_client_not_found', __( 'No Saddle client with that ID.', 'saddle' ), array( 'status' => 404 ) );
 		}
 
@@ -958,13 +972,15 @@ class Saddle_REST_Admin {
 
 		list( $raw_password, $new_item ) = $created;
 
-		// Swap the last-4 hint: old uuid out, new one in.
+		// Swap the last-4 hint and the issued marker: old uuid out, new one in.
 		$hint  = substr( str_replace( ' ', '', $raw_password ), -4 );
 		$hints = get_user_meta( $user->ID, 'saddle_client_hints', true );
 		$hints = is_array( $hints ) ? $hints : array();
 		unset( $hints[ $uuid ] );
 		$hints[ $new_item['uuid'] ] = $hint;
 		update_user_meta( $user->ID, 'saddle_client_hints', $hints );
+		Saddle_Connection::unmark_issued( $user->ID, $uuid );
+		Saddle_Connection::mark_issued( $user->ID, $new_item['uuid'] );
 
 		return new WP_REST_Response(
 			array(

--- a/includes/class-saddle-approval.php
+++ b/includes/class-saddle-approval.php
@@ -156,7 +156,8 @@ class Saddle_Approval {
 	}
 
 	/**
-	 * Create and persist a single-use token bound to an action and target.
+	 * Create and persist a single-use token bound to an action, a target, and
+	 * the previewing user.
 	 *
 	 * @param string $action Action identifier.
 	 * @param string $target Target identifier the token is bound to (e.g. post id).
@@ -197,6 +198,10 @@ class Saddle_Approval {
 		update_post_meta( $post_id, '_saddle_action', $action );
 		update_post_meta( $post_id, '_saddle_target', $target );
 		update_post_meta( $post_id, '_saddle_bind', $bind );
+		// The token belongs to whoever saw the preview: with several agents on
+		// one site (separate app passwords / users), agent A's preview must
+		// not be confirmable by agent B.
+		update_post_meta( $post_id, '_saddle_user', get_current_user_id() );
 		update_post_meta( $post_id, '_saddle_expires', time() + self::TOKEN_TTL );
 
 		return $token;
@@ -218,7 +223,7 @@ class Saddle_Approval {
 	/**
 	 * Validate and consume a token. Single-use: the token record is deleted on
 	 * lookup regardless of outcome, so even a mismatched/expired token cannot be
-	 * retried.
+	 * retried. The consumer must be the same user the preview was issued to.
 	 *
 	 * @param string $token  Candidate token.
 	 * @param string $action Action the token must be bound to.
@@ -257,10 +262,19 @@ class Saddle_Approval {
 		$stored_action = get_post_meta( $post_id, '_saddle_action', true );
 		$stored_target = (string) get_post_meta( $post_id, '_saddle_target', true );
 		$stored_bind   = (string) get_post_meta( $post_id, '_saddle_bind', true );
+		$stored_user   = (int) get_post_meta( $post_id, '_saddle_user', true );
 		$expires       = (int) get_post_meta( $post_id, '_saddle_expires', true );
 
 		// Single-use: burn the token now, before any further branching.
 		wp_delete_post( $post_id, true );
+
+		if ( $stored_user !== get_current_user_id() ) {
+			return new WP_Error(
+				'saddle_token_user_mismatch',
+				__( 'This confirmation token was issued to a different user. Preview the action yourself, then confirm with the token it returns.', 'saddle' ),
+				array( 'status' => 403 )
+			);
+		}
 
 		if ( $stored_action !== $action ) {
 			return new WP_Error(

--- a/includes/class-saddle-capabilities.php
+++ b/includes/class-saddle-capabilities.php
@@ -61,6 +61,15 @@ class Saddle_Capabilities {
 	const TIER_DOMAIN_OPTION = 'saddle_tier_domain';
 
 	/**
+	 * Option key for opt-in domain-drift enforcement. Off by default (warn
+	 * only). When on, write- and admin-tier abilities are refused while the
+	 * current domain differs from the one the tier was granted on — a cloned
+	 * or migrated database then lands read-only until the owner re-confirms
+	 * the access level (set_tier re-records the domain).
+	 */
+	const ENFORCE_DOMAIN_OPTION = 'saddle_enforce_tier_domain';
+
+	/**
 	 * Tier name => numeric rank. Higher rank = more power.
 	 *
 	 * @var array<string,int>
@@ -178,6 +187,11 @@ class Saddle_Capabilities {
 				return false;
 			}
 
+			if ( 'read' !== $level && self::is_domain_enforced() && ! self::domain_matches_recorded() ) {
+				self::log_denial( $short_name, 'domain' );
+				return false;
+			}
+
 			if ( ! self::tier_allows( $level ) ) {
 				self::log_denial( $short_name, 'tier' );
 				return false;
@@ -239,6 +253,12 @@ class Saddle_Capabilities {
 		if ( $ability ) {
 			$meta     = $ability->get_meta();
 			$required = isset( $meta['saddle']['tier'] ) ? (string) $meta['saddle']['tier'] : '';
+			if ( 'read' !== $required && '' !== $required && self::is_domain_enforced() && ! self::domain_matches_recorded() ) {
+				return array(
+					'code'    => 'saddle_domain_drift',
+					'message' => __( 'This site\'s domain changed since write access was granted, and the owner has domain enforcement on — write tools are refused until they re-confirm the access level (Saddle → Permissions). Do not retry; tell the user.', 'saddle' ),
+				);
+			}
 			if ( '' !== $required && ! self::tier_allows( $required ) ) {
 				return array(
 					'code'    => 'saddle_tier_denied',
@@ -267,7 +287,7 @@ class Saddle_Capabilities {
 	 * flood the log, and it never fires for anonymous requests.
 	 *
 	 * @param string|null $short_name Ability id without the 'saddle/' prefix.
-	 * @param string      $reason     'paused' | 'capability' | 'disabled' | 'tier'.
+	 * @param string      $reason     'paused' | 'capability' | 'disabled' | 'domain' | 'tier'.
 	 */
 	private static function log_denial( $short_name, $reason ) {
 		if ( ! class_exists( 'Saddle_Log' ) ) {
@@ -295,6 +315,10 @@ class Saddle_Capabilities {
 			case 'disabled':
 				/* translators: %s: tool name. */
 				$summary = sprintf( __( 'Blocked: the tool "%s" is turned off.', 'saddle' ), $tool );
+				break;
+			case 'domain':
+				/* translators: %s: tool name. */
+				$summary = sprintf( __( 'Blocked: the site domain changed since write access was granted — "%s" is refused until the access level is re-confirmed.', 'saddle' ), $tool );
 				break;
 			case 'tier':
 			default:
@@ -331,6 +355,25 @@ class Saddle_Capabilities {
 	 */
 	public static function set_paused( $paused ) {
 		return update_option( self::PAUSED_OPTION, (bool) $paused );
+	}
+
+	/**
+	 * Whether domain-drift enforcement is on (see ENFORCE_DOMAIN_OPTION).
+	 *
+	 * @return bool
+	 */
+	public static function is_domain_enforced() {
+		return (bool) get_option( self::ENFORCE_DOMAIN_OPTION, false );
+	}
+
+	/**
+	 * Turn domain-drift enforcement on or off.
+	 *
+	 * @param bool $enforce Whether write/admin abilities require the recorded domain.
+	 * @return bool
+	 */
+	public static function set_domain_enforcement( $enforce ) {
+		return update_option( self::ENFORCE_DOMAIN_OPTION, (bool) $enforce );
 	}
 
 	/**

--- a/includes/class-saddle-connection.php
+++ b/includes/class-saddle-connection.php
@@ -34,6 +34,15 @@ class Saddle_Connection {
 	const HTACCESS_MARKER = 'Saddle Authorization Header';
 
 	/**
+	 * User-meta key recording the UUIDs of app passwords Saddle issued.
+	 *
+	 * The immutable identity credential scoping keys on: the display name
+	 * ("Saddle: …") is user-editable in wp-admin, and scoping that silently
+	 * stops applying after a rename would hand the key full wp/v2 access.
+	 */
+	const ISSUED_META = 'saddle_issued_credentials';
+
+	/**
 	 * Scope Saddle-issued credentials to Saddle's own REST surface.
 	 *
 	 * A core Application Password authenticates the ENTIRE REST API as its
@@ -75,7 +84,7 @@ class Saddle_Connection {
 		$uuid = function_exists( 'rest_get_authenticated_app_password' )
 			? rest_get_authenticated_app_password()
 			: null;
-		if ( ! $uuid || ! self::is_saddle_credential( get_current_user_id(), $uuid ) ) {
+		if ( ! $uuid || ! self::is_saddle_issued( get_current_user_id(), $uuid ) ) {
 			return $response;
 		}
 
@@ -134,8 +143,10 @@ class Saddle_Connection {
 		if ( ! apply_filters( 'saddle_scope_credentials', true ) ) {
 			return;
 		}
-		$prefix = class_exists( 'Saddle_REST_Admin' ) ? Saddle_REST_Admin::CLIENT_PREFIX : 'Saddle: ';
-		if ( isset( $item['name'] ) && 0 === strpos( (string) $item['name'], $prefix ) ) {
+		$is_saddle = isset( $item['uuid'] ) && $user instanceof WP_User
+			? self::is_saddle_issued( $user->ID, (string) $item['uuid'] )
+			: ( isset( $item['name'] ) && 0 === strpos( (string) $item['name'], class_exists( 'Saddle_REST_Admin' ) ? Saddle_REST_Admin::CLIENT_PREFIX : 'Saddle: ' ) );
+		if ( $is_saddle ) {
 			$error->add(
 				'saddle_credential_scope',
 				__( 'Saddle sign-in keys cannot be used over XML-RPC.', 'saddle' )
@@ -144,23 +155,73 @@ class Saddle_Connection {
 	}
 
 	/**
-	 * Whether the given application password UUID is one Saddle issued
-	 * (identified by the `Saddle: ` name prefix) for this user.
+	 * Record an app-password UUID as Saddle-issued for a user.
+	 *
+	 * @param int    $user_id User the credential belongs to.
+	 * @param string $uuid    Application password UUID.
+	 */
+	public static function mark_issued( $user_id, $uuid ) {
+		$uuids = get_user_meta( (int) $user_id, self::ISSUED_META, true );
+		$uuids = is_array( $uuids ) ? $uuids : array();
+		if ( ! in_array( (string) $uuid, $uuids, true ) ) {
+			$uuids[] = (string) $uuid;
+			update_user_meta( (int) $user_id, self::ISSUED_META, $uuids );
+		}
+	}
+
+	/**
+	 * Forget a revoked credential's UUID.
+	 *
+	 * @param int    $user_id User the credential belonged to.
+	 * @param string $uuid    Application password UUID.
+	 */
+	public static function unmark_issued( $user_id, $uuid ) {
+		$uuids = get_user_meta( (int) $user_id, self::ISSUED_META, true );
+		if ( ! is_array( $uuids ) || ! in_array( (string) $uuid, $uuids, true ) ) {
+			return;
+		}
+		$uuids = array_values( array_diff( $uuids, array( (string) $uuid ) ) );
+		if ( $uuids ) {
+			update_user_meta( (int) $user_id, self::ISSUED_META, $uuids );
+		} else {
+			delete_user_meta( (int) $user_id, self::ISSUED_META );
+		}
+	}
+
+	/**
+	 * Whether the given application password UUID is one Saddle issued for
+	 * this user.
+	 *
+	 * Keyed on the stored UUID marker, which survives a rename in wp-admin →
+	 * Application Passwords. Keys issued before the marker existed are only
+	 * recognizable by their `Saddle: ` name prefix — those migrate into the
+	 * marker on first sight, so a later rename can no longer un-scope them.
 	 *
 	 * @param int    $user_id User the request authenticated as.
 	 * @param string $uuid    Application password UUID.
 	 * @return bool
 	 */
-	private static function is_saddle_credential( $user_id, $uuid ) {
-		if ( ! $user_id || ! class_exists( 'WP_Application_Passwords' ) ) {
+	public static function is_saddle_issued( $user_id, $uuid ) {
+		if ( ! $user_id || '' === (string) $uuid || ! class_exists( 'WP_Application_Passwords' ) ) {
 			return false;
 		}
+
+		$uuids = get_user_meta( (int) $user_id, self::ISSUED_META, true );
+		if ( is_array( $uuids ) && in_array( (string) $uuid, $uuids, true ) ) {
+			return true;
+		}
+
 		$item = WP_Application_Passwords::get_user_application_password( (int) $user_id, (string) $uuid );
 		if ( ! $item || empty( $item['name'] ) ) {
 			return false;
 		}
 		$prefix = class_exists( 'Saddle_REST_Admin' ) ? Saddle_REST_Admin::CLIENT_PREFIX : 'Saddle: ';
-		return 0 === strpos( (string) $item['name'], $prefix );
+		if ( 0 === strpos( (string) $item['name'], $prefix ) ) {
+			self::mark_issued( (int) $user_id, (string) $uuid );
+			return true;
+		}
+
+		return false;
 	}
 
 	/**

--- a/includes/class-saddle-log.php
+++ b/includes/class-saddle-log.php
@@ -228,14 +228,35 @@ class Saddle_Log {
 	/**
 	 * Trim the log to a bounded number of entries (keeps it from growing without
 	 * limit). Wired to the same hourly cron as the approval-token GC.
+	 *
+	 * Denials and executed mutations are capped SEPARATELY: they share one
+	 * CPT, and under a single cap a burst of denial noise (many tools × many
+	 * reasons) could evict the security-relevant "what did the agent actually
+	 * change" history.
 	 */
 	public static function gc() {
 		/**
-		 * Filter the maximum number of activity log entries to retain.
+		 * Filter the maximum number of executed-mutation log entries to retain.
 		 *
 		 * @param int $max Maximum entries. Default 1000.
 		 */
-		$max = (int) apply_filters( 'saddle_log_max_entries', 1000 );
+		self::trim( (int) apply_filters( 'saddle_log_max_entries', 1000 ), false );
+
+		/**
+		 * Filter the maximum number of denial log entries to retain.
+		 *
+		 * @param int $max Maximum denial entries. Default 300.
+		 */
+		self::trim( (int) apply_filters( 'saddle_log_max_denials', 300 ), true );
+	}
+
+	/**
+	 * Delete one bucket's entries beyond its cap, oldest first.
+	 *
+	 * @param int  $max    Entries to retain; below 1 the bucket is left alone.
+	 * @param bool $denied True to trim denial entries, false for executed ones.
+	 */
+	private static function trim( $max, $denied ) {
 		if ( $max < 1 ) {
 			return;
 		}
@@ -244,12 +265,31 @@ class Saddle_Log {
 			array(
 				'post_type'      => self::CPT,
 				'post_status'    => 'publish',
-				'posts_per_page' => 200, // phpcs:ignore WordPress.WP.PostsPerPage.posts_per_page_posts_per_page -- Bounded GC batch trimming a private log CPT to its cap.
+				'posts_per_page' => 500, // phpcs:ignore WordPress.WP.PostsPerPage.posts_per_page_posts_per_page -- Bounded GC batch trimming a private log CPT to its cap.
 				'offset'         => $max,
 				'orderby'        => 'date',
 				'order'          => 'DESC',
 				'fields'         => 'ids',
 				'no_found_rows'  => true,
+				'meta_query'     => $denied // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query -- Bounded private CPT; the type filter is the point of the split caps.
+					? array(
+						array(
+							'key'   => '_saddle_type',
+							'value' => 'denied',
+						),
+					)
+					: array(
+						'relation' => 'OR',
+						array(
+							'key'     => '_saddle_type',
+							'compare' => 'NOT EXISTS',
+						),
+						array(
+							'key'     => '_saddle_type',
+							'value'   => 'denied',
+							'compare' => '!=',
+						),
+					),
 			)
 		);
 

--- a/tests/approval-test.php
+++ b/tests/approval-test.php
@@ -245,6 +245,25 @@ class Saddle_Approval_Test extends WP_UnitTestCase {
 		$this->assertSame( 'saddle_gate_misconfigured', $result->get_error_code() );
 	}
 
+	/**
+	 * With several agents on one site (separate users / app passwords), a
+	 * token previewed by one user must never be confirmable by another.
+	 */
+	public function test_token_bound_to_user_rejects_a_different_user() {
+		$issuer = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		$other  = self::factory()->user->create( array( 'role' => 'administrator' ) );
+
+		wp_set_current_user( $issuer );
+		$token = Saddle_Approval::gate( $this->gate_args( $calls ) )['confirm_token'];
+
+		wp_set_current_user( $other );
+		$result = Saddle_Approval::gate( $this->gate_args( $calls, array( 'input' => array( 'confirm_token' => $token ) ) ) );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'saddle_token_user_mismatch', $result->get_error_code() );
+		$this->assertSame( 0, $calls, 'Another user must never confirm a token they did not preview.' );
+	}
+
 	/* -------- audit logging -------- */
 
 	/**

--- a/tests/log-test.php
+++ b/tests/log-test.php
@@ -64,4 +64,29 @@ class Saddle_Log_Test extends WP_UnitTestCase {
 	public function cap_at_five() {
 		return 5;
 	}
+
+	/**
+	 * Denials and executed mutations are capped as separate buckets, so a
+	 * flood of denial noise can never evict real change history.
+	 */
+	public function test_gc_caps_denials_and_mutations_independently() {
+		add_filter( 'saddle_log_max_entries', array( $this, 'cap_at_five' ) );
+		add_filter( 'saddle_log_max_denials', array( $this, 'cap_at_three' ) );
+
+		for ( $i = 0; $i < 9; $i++ ) {
+			Saddle_Log::record( array( 'action' => "mutation-{$i}", 'summary' => "mutation {$i}" ) );
+			Saddle_Log::record( array( 'action' => "denied-{$i}", 'summary' => "denial {$i}", 'type' => 'denied' ) );
+		}
+		Saddle_Log::gc();
+
+		remove_filter( 'saddle_log_max_entries', array( $this, 'cap_at_five' ) );
+		remove_filter( 'saddle_log_max_denials', array( $this, 'cap_at_three' ) );
+
+		$this->assertSame( 5, Saddle_Log::query( 100, 1, 'executed' )['total'], 'Executed history must keep its own cap.' );
+		$this->assertSame( 3, Saddle_Log::query( 100, 1, 'denied' )['total'], 'Denials must be trimmed to their own, smaller cap.' );
+	}
+
+	public function cap_at_three() {
+		return 3;
+	}
 }

--- a/tests/scoping-test.php
+++ b/tests/scoping-test.php
@@ -166,6 +166,57 @@ class Saddle_Scoping_Test extends WP_UnitTestCase {
 		$this->assertSame( 200, $res->get_status() );
 	}
 
+	/* -------- the immutable issued marker -------- */
+
+	/**
+	 * The scope must key on the stored UUID marker, not the display name —
+	 * renaming the key in wp-admin → Application Passwords must not silently
+	 * hand it full wp/v2 access.
+	 */
+	public function test_renamed_saddle_credential_stays_scoped() {
+		$created = WP_Application_Passwords::create_new_application_password(
+			$this->admin,
+			array( 'name' => 'Saddle: Claude Code' )
+		);
+		$this->assertNotWPError( $created );
+		$uuid = $created[1]['uuid'];
+
+		// Issued the way create_client issues: marker recorded at creation.
+		Saddle_Connection::mark_issued( $this->admin, $uuid );
+
+		// The owner renames the key — the prefix is gone.
+		WP_Application_Passwords::update_application_password( $this->admin, $uuid, array( 'name' => 'my api key' ) );
+
+		$user = wp_authenticate_application_password( null, $this->login, $created[0] );
+		$this->assertInstanceOf( 'WP_User', $user );
+		wp_set_current_user( $user->ID );
+
+		$res = rest_do_request( new WP_REST_Request( 'GET', '/wp/v2/posts' ) );
+		$this->assertSame( 403, $res->get_status(), 'A renamed Saddle key must stay confined to the MCP endpoint.' );
+		$this->assertSame( 'saddle_credential_scope', $res->as_error()->get_error_code() );
+	}
+
+	/**
+	 * Keys issued before the marker existed are recognized by their name
+	 * prefix and migrate into the marker on first sight.
+	 */
+	public function test_legacy_prefix_key_migrates_into_the_marker() {
+		$created = WP_Application_Passwords::create_new_application_password(
+			$this->admin,
+			array( 'name' => 'Saddle: Legacy Key' )
+		);
+		$this->assertNotWPError( $created );
+		$uuid = $created[1]['uuid'];
+
+		$this->assertEmpty( get_user_meta( $this->admin, Saddle_Connection::ISSUED_META, true ), 'A legacy key starts unmarked.' );
+		$this->assertTrue( Saddle_Connection::is_saddle_issued( $this->admin, $uuid ) );
+		$this->assertContains(
+			$uuid,
+			(array) get_user_meta( $this->admin, Saddle_Connection::ISSUED_META, true ),
+			'Prefix recognition must migrate the key into the marker so a later rename cannot un-scope it.'
+		);
+	}
+
 	/* -------- XML-RPC surface -------- */
 
 	public function test_saddle_credential_is_refused_over_xmlrpc() {


### PR DESCRIPTION
Closes #63. Stacked on #66 (Phase 1).

- Approval tokens bound to the previewing user (cross-agent redemption closed).
- Credential scoping keys on an immutable stored UUID marker, rename-proof; legacy keys migrate on sight.
- Separate log GC caps for denials vs executed mutations.
- Opt-in domain-drift enforcement (default stays warn-only).

Wrapper `bind` + partner-annotation fail-safety (2.2/2.3) land inside the shared integration engine in Phase 3 rather than being patched into both twins twice.

Tests: 4 new (user mismatch, split caps, rename-proof scoping, legacy migration); suite green (365 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0133CZhoFPY6BBChDDGEa22Q