### PR TITLE
Plugin Check compliance for the wp.org 1.0.0 submission

### DIFF
--- a/includes/lib/wp-mcp/includes/Autoloader.php
+++ b/includes/lib/wp-mcp/includes/Autoloader.php
@@ -72,7 +72,7 @@ final class Autoloader {
 			add_action(
 				$hook,
 				static function () {
-					$error_message = __( 'MCP Adapter: The Composer autoloader was not found. If you installed the plugin from the GitHub source code, make sure to run `composer install`.', 'mcp-adapter' );
+					$error_message = __( 'MCP Adapter: The Composer autoloader was not found. If you installed the plugin from the GitHub source code, make sure to run `composer install`.', 'saddle' );
 
 					if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
 						error_log( esc_html( $error_message ) ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log -- This is a development notice.

--- a/includes/lib/wp-mcp/includes/Core/McpAdapter.php
+++ b/includes/lib/wp-mcp/includes/Core/McpAdapter.php
@@ -178,7 +178,7 @@ final class McpAdapter {
 				'invalid_error_handler',
 				sprintf(
 					/* translators: %s: error handler class name */
-					esc_html__( 'Error handler class "%s" does not exist.', 'mcp-adapter' ),
+					esc_html__( 'Error handler class "%s" does not exist.', 'saddle' ),
 					esc_html( $error_handler )
 				)
 			);
@@ -189,7 +189,7 @@ final class McpAdapter {
 				'invalid_error_handler',
 				sprintf(
 				/* translators: %s: error handler class name */
-					esc_html__( 'Error handler class "%s" must implement the McpErrorHandlerInterface.', 'mcp-adapter' ),
+					esc_html__( 'Error handler class "%s" must implement the McpErrorHandlerInterface.', 'saddle' ),
 					esc_html( $error_handler )
 				)
 			);
@@ -206,7 +206,7 @@ final class McpAdapter {
 				'invalid_observability_handler',
 				sprintf(
 				/* translators: %s: observability handler class name */
-					esc_html__( 'Observability handler class "%s" does not exist.', 'mcp-adapter' ),
+					esc_html__( 'Observability handler class "%s" does not exist.', 'saddle' ),
 					esc_html( $observability_handler )
 				)
 			);
@@ -217,7 +217,7 @@ final class McpAdapter {
 				'invalid_observability_handler',
 				sprintf(
 				/* translators: %s: observability handler class name */
-					esc_html__( 'Observability handler class "%s" must implement the McpObservabilityHandlerInterface interface.', 'mcp-adapter' ),
+					esc_html__( 'Observability handler class "%s" must implement the McpObservabilityHandlerInterface interface.', 'saddle' ),
 					esc_html( $observability_handler )
 				)
 			);
@@ -226,13 +226,13 @@ final class McpAdapter {
 		if ( ! doing_action( 'mcp_adapter_init' ) ) {
 			_doing_it_wrong(
 				__FUNCTION__,
-				esc_html__( 'MCP Servers must be created during the "mcp_adapter_init" action. Hook into "mcp_adapter_init" to register your server.', 'mcp-adapter' ),
+				esc_html__( 'MCP Servers must be created during the "mcp_adapter_init" action. Hook into "mcp_adapter_init" to register your server.', 'saddle' ),
 				'0.1.0'
 			);
 
 			return new WP_Error(
 				'invalid_timing',
-				esc_html__( 'MCP Server creation must be done during mcp_adapter_init action.', 'mcp-adapter' )
+				esc_html__( 'MCP Server creation must be done during mcp_adapter_init action.', 'saddle' )
 			);
 		}
 
@@ -241,7 +241,7 @@ final class McpAdapter {
 				__FUNCTION__,
 				sprintf(
 				// translators: %s: server ID
-					esc_html__( 'Server with ID "%s" already exists. Each server must have a unique ID.', 'mcp-adapter' ),
+					esc_html__( 'Server with ID "%s" already exists. Each server must have a unique ID.', 'saddle' ),
 					esc_html( $server_id )
 				),
 				'0.1.0'
@@ -250,7 +250,7 @@ final class McpAdapter {
 			return new WP_Error(
 				'duplicate_server_id',
 				// translators: %s: server ID.
-				sprintf( esc_html__( 'Server with ID "%s" already exists.', 'mcp-adapter' ), esc_html( $server_id ) )
+				sprintf( esc_html__( 'Server with ID "%s" already exists.', 'saddle' ), esc_html( $server_id ) )
 			);
 		}
 
@@ -276,7 +276,7 @@ final class McpAdapter {
 				'server_creation_failed',
 				sprintf(
 					/* translators: 1: server ID, 2: error message */
-					esc_html__( 'Failed to create server "%1$s": %2$s', 'mcp-adapter' ),
+					esc_html__( 'Failed to create server "%1$s": %2$s', 'saddle' ),
 					esc_html( $server_id ),
 					esc_html( $e->getMessage() )
 				)

--- a/includes/lib/wp-mcp/includes/Core/McpTransportFactory.php
+++ b/includes/lib/wp-mcp/includes/Core/McpTransportFactory.php
@@ -50,7 +50,7 @@ class McpTransportFactory {
 					__FUNCTION__,
 					sprintf(
 					/* translators: %s: Transport class name */
-						esc_html__( 'Transport class "%s" does not exist. Make sure the class is properly autoloaded or included.', 'mcp-adapter' ),
+						esc_html__( 'Transport class "%s" does not exist. Make sure the class is properly autoloaded or included.', 'saddle' ),
 						esc_html( $mcp_transport )
 					),
 					'0.1.0'
@@ -69,7 +69,7 @@ class McpTransportFactory {
 					__FUNCTION__,
 					sprintf(
 					/* translators: %s: Transport class name */
-						esc_html__( 'Transport class "%s" must implement McpTransportInterface. Check your transport implementation.', 'mcp-adapter' ),
+						esc_html__( 'Transport class "%s" must implement McpTransportInterface. Check your transport implementation.', 'saddle' ),
 						esc_html( $mcp_transport )
 					),
 					'0.1.0'

--- a/includes/lib/wp-mcp/includes/Domain/Prompts/McpPrompt.php
+++ b/includes/lib/wp-mcp/includes/Domain/Prompts/McpPrompt.php
@@ -194,7 +194,7 @@ final class McpPrompt implements McpComponentInterface {
 				'mcp_prompt_dto_creation_failed',
 				sprintf(
 				/* translators: %s: error message */
-					__( 'Failed to create Prompt DTO: %s', 'mcp-adapter' ),
+					__( 'Failed to create Prompt DTO: %s', 'saddle' ),
 					$e->getMessage()
 				),
 				array( 'exception' => $e )

--- a/includes/lib/wp-mcp/includes/Domain/Prompts/McpPromptValidator.php
+++ b/includes/lib/wp-mcp/includes/Domain/Prompts/McpPromptValidator.php
@@ -39,7 +39,7 @@ class McpPromptValidator {
 			$error_message  = $context ? "[{$context}] " : '';
 			$error_message .= sprintf(
 			/* translators: %s: comma-separated list of validation errors */
-				__( 'Prompt validation failed: %s', 'mcp-adapter' ),
+				__( 'Prompt validation failed: %s', 'saddle' ),
 				implode( ', ', $validation_errors )
 			);
 			return new WP_Error( 'mcp_prompt_validation_failed', esc_html( $error_message ) );
@@ -60,7 +60,7 @@ class McpPromptValidator {
 
 		// Validate name.
 		if ( ! McpValidator::validate_name( $prompt->getName() ) ) {
-			$errors[] = __( 'Prompt name must be 1-128 characters and contain only [A-Za-z0-9_.-]', 'mcp-adapter' );
+			$errors[] = __( 'Prompt name must be 1-128 characters and contain only [A-Za-z0-9_.-]', 'saddle' );
 		}
 
 		// Validate icons if present.
@@ -81,7 +81,7 @@ class McpPromptValidator {
 				'mcp_prompt_validation_failed',
 				sprintf(
 				/* translators: %s: list of validation errors */
-					__( 'Prompt validation failed: %s', 'mcp-adapter' ),
+					__( 'Prompt validation failed: %s', 'saddle' ),
 					implode( '; ', $errors )
 				)
 			);
@@ -115,16 +115,16 @@ class McpPromptValidator {
 
 		// Check required fields
 		if ( empty( $prompt_data['name'] ) || ! is_string( $prompt_data['name'] ) || ! McpValidator::validate_name( $prompt_data['name'] ) ) {
-			$errors[] = __( 'Prompt name is required and must be 1-128 characters and contain only [A-Za-z0-9_.-]', 'mcp-adapter' );
+			$errors[] = __( 'Prompt name is required and must be 1-128 characters and contain only [A-Za-z0-9_.-]', 'saddle' );
 		}
 
 		// Check optional fields if present
 		if ( isset( $prompt_data['title'] ) && ! is_string( $prompt_data['title'] ) ) {
-			$errors[] = __( 'Prompt title must be a string if provided', 'mcp-adapter' );
+			$errors[] = __( 'Prompt title must be a string if provided', 'saddle' );
 		}
 
 		if ( isset( $prompt_data['description'] ) && ! is_string( $prompt_data['description'] ) ) {
-			$errors[] = __( 'Prompt description must be a string if provided', 'mcp-adapter' );
+			$errors[] = __( 'Prompt description must be a string if provided', 'saddle' );
 		}
 
 		// Validate arguments (optional field)
@@ -150,7 +150,7 @@ class McpPromptValidator {
 
 		// Arguments must be an array
 		if ( ! is_array( $arguments ) ) {
-			return array( __( 'Prompt arguments must be an array if provided', 'mcp-adapter' ) );
+			return array( __( 'Prompt arguments must be an array if provided', 'saddle' ) );
 		}
 
 		// Validate each argument
@@ -158,7 +158,7 @@ class McpPromptValidator {
 			if ( ! is_array( $argument ) ) {
 				$errors[] = sprintf(
 				/* translators: %d: argument index */
-					__( 'Prompt argument at index %d must be an object', 'mcp-adapter' ),
+					__( 'Prompt argument at index %d must be an object', 'saddle' ),
 					$index
 				);
 				continue;
@@ -168,7 +168,7 @@ class McpPromptValidator {
 			if ( empty( $argument['name'] ) || ! is_string( $argument['name'] ) ) {
 				$errors[] = sprintf(
 				/* translators: %d: argument index */
-					__( 'Prompt argument at index %d must have a non-empty name string', 'mcp-adapter' ),
+					__( 'Prompt argument at index %d must have a non-empty name string', 'saddle' ),
 					$index
 				);
 				continue;
@@ -178,7 +178,7 @@ class McpPromptValidator {
 			if ( ! McpValidator::validate_name( $argument['name'] ) ) {
 				$errors[] = sprintf(
 				/* translators: %s: argument name */
-					__( 'Prompt argument \'%s\' name must only contain letters, numbers, hyphens (-), underscores (_), and dots (.), and be 128 characters or less', 'mcp-adapter' ),
+					__( 'Prompt argument \'%s\' name must only contain letters, numbers, hyphens (-), underscores (_), and dots (.), and be 128 characters or less', 'saddle' ),
 					$argument['name']
 				);
 			}
@@ -187,7 +187,7 @@ class McpPromptValidator {
 			if ( isset( $argument['description'] ) && ! is_string( $argument['description'] ) ) {
 				$errors[] = sprintf(
 				/* translators: %s: argument name */
-					__( 'Prompt argument \'%s\' description must be a string if provided', 'mcp-adapter' ),
+					__( 'Prompt argument \'%s\' description must be a string if provided', 'saddle' ),
 					$argument['name']
 				);
 			}
@@ -199,7 +199,7 @@ class McpPromptValidator {
 
 			$errors[] = sprintf(
 			/* translators: %s: argument name */
-				__( 'Prompt argument \'%s\' required field must be a boolean if provided', 'mcp-adapter' ),
+				__( 'Prompt argument \'%s\' required field must be a boolean if provided', 'saddle' ),
 				$argument['name']
 			);
 		}
@@ -221,7 +221,7 @@ class McpPromptValidator {
 			if ( ! is_array( $message ) ) {
 				$errors[] = sprintf(
 				/* translators: %d: message index */
-					__( 'Message at index %d must be an object', 'mcp-adapter' ),
+					__( 'Message at index %d must be an object', 'saddle' ),
 					$index
 				);
 				continue;
@@ -231,7 +231,7 @@ class McpPromptValidator {
 			if ( empty( $message['role'] ) || ! is_string( $message['role'] ) ) {
 				$errors[] = sprintf(
 				/* translators: %d: message index */
-					__( 'Message at index %d must have a role field', 'mcp-adapter' ),
+					__( 'Message at index %d must have a role field', 'saddle' ),
 					$index
 				);
 				continue;
@@ -241,7 +241,7 @@ class McpPromptValidator {
 			if ( ! in_array( $message['role'], array( 'user', 'assistant' ), true ) ) {
 				$errors[] = sprintf(
 				/* translators: %d: message index */
-					__( 'Message at index %d role must be either \'user\' or \'assistant\'', 'mcp-adapter' ),
+					__( 'Message at index %d role must be either \'user\' or \'assistant\'', 'saddle' ),
 					$index
 				);
 			}
@@ -250,7 +250,7 @@ class McpPromptValidator {
 			if ( empty( $message['content'] ) || ! is_array( $message['content'] ) ) {
 				$errors[] = sprintf(
 				/* translators: %d: message index */
-					__( 'Message at index %d must have a content object', 'mcp-adapter' ),
+					__( 'Message at index %d must have a content object', 'saddle' ),
 					$index
 				);
 				continue;
@@ -283,7 +283,7 @@ class McpPromptValidator {
 				foreach ( $error_group['errors'] as $error ) {
 					$errors[] = sprintf(
 					/* translators: 1: icon index, 2: error message */
-						__( 'Icon at index %1$d: %2$s', 'mcp-adapter' ),
+						__( 'Icon at index %1$d: %2$s', 'saddle' ),
 						$error_group['index'],
 						$error
 					);
@@ -310,7 +310,7 @@ class McpPromptValidator {
 			return array(
 				sprintf(
 				/* translators: %d: message index */
-					__( 'Message %d content must have a type field', 'mcp-adapter' ),
+					__( 'Message %d content must have a type field', 'saddle' ),
 					$message_index
 				),
 			);
@@ -323,7 +323,7 @@ class McpPromptValidator {
 				if ( ! isset( $content['text'] ) || ! is_string( $content['text'] ) ) {
 					$errors[] = sprintf(
 					/* translators: %d: message index */
-						__( 'Message %d text content must have a text field', 'mcp-adapter' ),
+						__( 'Message %d text content must have a text field', 'saddle' ),
 						$message_index
 					);
 				}
@@ -333,13 +333,13 @@ class McpPromptValidator {
 				if ( empty( $content['data'] ) || ! is_string( $content['data'] ) ) {
 					$errors[] = sprintf(
 					/* translators: %d: message index */
-						__( 'Message %d image content must have a data field with base64-encoded image', 'mcp-adapter' ),
+						__( 'Message %d image content must have a data field with base64-encoded image', 'saddle' ),
 						$message_index
 					);
 				} elseif ( ! McpValidator::validate_base64( $content['data'] ) ) {
 					$errors[] = sprintf(
 					/* translators: %d: message index */
-						__( 'Message %d image content data must be valid base64', 'mcp-adapter' ),
+						__( 'Message %d image content data must be valid base64', 'saddle' ),
 						$message_index
 					);
 				}
@@ -347,13 +347,13 @@ class McpPromptValidator {
 				if ( empty( $content['mimeType'] ) || ! is_string( $content['mimeType'] ) ) {
 					$errors[] = sprintf(
 					/* translators: %d: message index */
-						__( 'Message %d image content must have a mimeType field', 'mcp-adapter' ),
+						__( 'Message %d image content must have a mimeType field', 'saddle' ),
 						$message_index
 					);
 				} elseif ( ! McpValidator::validate_image_mime_type( $content['mimeType'] ) ) {
 					$errors[] = sprintf(
 					/* translators: %d: message index */
-						__( 'Message %d image content must have a valid image MIME type', 'mcp-adapter' ),
+						__( 'Message %d image content must have a valid image MIME type', 'saddle' ),
 						$message_index
 					);
 				}
@@ -363,13 +363,13 @@ class McpPromptValidator {
 				if ( empty( $content['data'] ) || ! is_string( $content['data'] ) ) {
 					$errors[] = sprintf(
 					/* translators: %d: message index */
-						__( 'Message %d audio content must have a data field with base64-encoded audio', 'mcp-adapter' ),
+						__( 'Message %d audio content must have a data field with base64-encoded audio', 'saddle' ),
 						$message_index
 					);
 				} elseif ( ! McpValidator::validate_base64( $content['data'] ) ) {
 					$errors[] = sprintf(
 					/* translators: %d: message index */
-						__( 'Message %d audio content data must be valid base64', 'mcp-adapter' ),
+						__( 'Message %d audio content data must be valid base64', 'saddle' ),
 						$message_index
 					);
 				}
@@ -377,13 +377,13 @@ class McpPromptValidator {
 				if ( empty( $content['mimeType'] ) || ! is_string( $content['mimeType'] ) ) {
 					$errors[] = sprintf(
 					/* translators: %d: message index */
-						__( 'Message %d audio content must have a mimeType field', 'mcp-adapter' ),
+						__( 'Message %d audio content must have a mimeType field', 'saddle' ),
 						$message_index
 					);
 				} elseif ( ! McpValidator::validate_audio_mime_type( $content['mimeType'] ) ) {
 					$errors[] = sprintf(
 					/* translators: %d: message index */
-						__( 'Message %d audio content must have a valid audio MIME type', 'mcp-adapter' ),
+						__( 'Message %d audio content must have a valid audio MIME type', 'saddle' ),
 						$message_index
 					);
 				}
@@ -394,7 +394,7 @@ class McpPromptValidator {
 				if ( empty( $content['name'] ) || ! is_string( $content['name'] ) ) {
 					$errors[] = sprintf(
 					/* translators: %d: message index */
-						__( 'Message %d resource_link content must have a name field', 'mcp-adapter' ),
+						__( 'Message %d resource_link content must have a name field', 'saddle' ),
 						$message_index
 					);
 				}
@@ -402,13 +402,13 @@ class McpPromptValidator {
 				if ( empty( $content['uri'] ) || ! is_string( $content['uri'] ) ) {
 					$errors[] = sprintf(
 					/* translators: %d: message index */
-						__( 'Message %d resource_link content must have a uri field', 'mcp-adapter' ),
+						__( 'Message %d resource_link content must have a uri field', 'saddle' ),
 						$message_index
 					);
 				} elseif ( ! McpValidator::validate_resource_uri( $content['uri'] ) ) {
 					$errors[] = sprintf(
 					/* translators: %d: message index */
-						__( 'Message %d resource_link content uri must be a valid URI format', 'mcp-adapter' ),
+						__( 'Message %d resource_link content uri must be a valid URI format', 'saddle' ),
 						$message_index
 					);
 				}
@@ -417,13 +417,13 @@ class McpPromptValidator {
 					if ( ! is_string( $content['mimeType'] ) ) {
 						$errors[] = sprintf(
 						/* translators: %d: message index */
-							__( 'Message %d resource_link content mimeType must be a string if provided', 'mcp-adapter' ),
+							__( 'Message %d resource_link content mimeType must be a string if provided', 'saddle' ),
 							$message_index
 						);
 					} elseif ( ! McpValidator::validate_mime_type( $content['mimeType'] ) ) {
 						$errors[] = sprintf(
 						/* translators: %d: message index */
-							__( 'Message %d resource_link content mimeType must be a valid MIME type format', 'mcp-adapter' ),
+							__( 'Message %d resource_link content mimeType must be a valid MIME type format', 'saddle' ),
 							$message_index
 						);
 					}
@@ -432,7 +432,7 @@ class McpPromptValidator {
 				if ( isset( $content['size'] ) && ! is_int( $content['size'] ) ) {
 					$errors[] = sprintf(
 					/* translators: %d: message index */
-						__( 'Message %d resource_link content size must be an integer if provided', 'mcp-adapter' ),
+						__( 'Message %d resource_link content size must be an integer if provided', 'saddle' ),
 						$message_index
 					);
 				}
@@ -440,7 +440,7 @@ class McpPromptValidator {
 				if ( isset( $content['title'] ) && ! is_string( $content['title'] ) ) {
 					$errors[] = sprintf(
 					/* translators: %d: message index */
-						__( 'Message %d resource_link content title must be a string if provided', 'mcp-adapter' ),
+						__( 'Message %d resource_link content title must be a string if provided', 'saddle' ),
 						$message_index
 					);
 				}
@@ -448,7 +448,7 @@ class McpPromptValidator {
 				if ( isset( $content['description'] ) && ! is_string( $content['description'] ) ) {
 					$errors[] = sprintf(
 					/* translators: %d: message index */
-						__( 'Message %d resource_link content description must be a string if provided', 'mcp-adapter' ),
+						__( 'Message %d resource_link content description must be a string if provided', 'saddle' ),
 						$message_index
 					);
 				}
@@ -457,7 +457,7 @@ class McpPromptValidator {
 					if ( ! is_array( $content['icons'] ) ) {
 						$errors[] = sprintf(
 						/* translators: %d: message index */
-							__( 'Message %d resource_link content icons must be an array if provided', 'mcp-adapter' ),
+							__( 'Message %d resource_link content icons must be an array if provided', 'saddle' ),
 							$message_index
 						);
 					} else {
@@ -472,7 +472,7 @@ class McpPromptValidator {
 				if ( empty( $content['resource'] ) || ! is_array( $content['resource'] ) ) {
 					$errors[] = sprintf(
 					/* translators: %d: message index */
-						__( 'Message %d resource content must have a resource object', 'mcp-adapter' ),
+						__( 'Message %d resource content must have a resource object', 'saddle' ),
 						$message_index
 					);
 				} else {
@@ -481,7 +481,7 @@ class McpPromptValidator {
 					foreach ( $resource_errors as $resource_error ) {
 						$errors[] = sprintf(
 						/* translators: %1$d: message index, %2$s: resource error */
-							__( 'Message %1$d embedded resource: %2$s', 'mcp-adapter' ),
+							__( 'Message %1$d embedded resource: %2$s', 'saddle' ),
 							$message_index,
 							$resource_error
 						);
@@ -492,7 +492,7 @@ class McpPromptValidator {
 			default:
 				$errors[] = sprintf(
 				/* translators: %1$d: message index, %2$s: content type */
-					__( 'Message %1$d content type \'%2$s\' is not supported. Must be \'text\', \'image\', \'audio\', \'resource\', or \'resource_link\'', 'mcp-adapter' ),
+					__( 'Message %1$d content type \'%2$s\' is not supported. Must be \'text\', \'image\', \'audio\', \'resource\', or \'resource_link\'', 'saddle' ),
 					$message_index,
 					$type
 				);
@@ -504,7 +504,7 @@ class McpPromptValidator {
 			if ( ! is_array( $content['annotations'] ) ) {
 				$errors[] = sprintf(
 				/* translators: %d: message index */
-					__( 'Message %d content annotations must be an array if provided', 'mcp-adapter' ),
+					__( 'Message %d content annotations must be an array if provided', 'saddle' ),
 					$message_index
 				);
 			} else {

--- a/includes/lib/wp-mcp/includes/Domain/Prompts/RegisterAbilityAsMcpPrompt.php
+++ b/includes/lib/wp-mcp/includes/Domain/Prompts/RegisterAbilityAsMcpPrompt.php
@@ -315,7 +315,7 @@ class RegisterAbilityAsMcpPrompt {
 					'mcp_prompt_invalid_argument',
 					sprintf(
 					/* translators: 1: argument index, 2: ability name */
-						__( 'Argument at index %1$d must be an array for ability "%2$s".', 'mcp-adapter' ),
+						__( 'Argument at index %1$d must be an array for ability "%2$s".', 'saddle' ),
 						$index,
 						$this->ability->get_name()
 					)
@@ -328,7 +328,7 @@ class RegisterAbilityAsMcpPrompt {
 					'mcp_prompt_argument_missing_name',
 					sprintf(
 					/* translators: 1: argument index, 2: ability name */
-						__( 'Argument at index %1$d is missing required "name" field for ability "%2$s".', 'mcp-adapter' ),
+						__( 'Argument at index %1$d is missing required "name" field for ability "%2$s".', 'saddle' ),
 						$index,
 						$this->ability->get_name()
 					)
@@ -467,7 +467,7 @@ class RegisterAbilityAsMcpPrompt {
 				'mcp_prompt_name_filter_invalid',
 				sprintf(
 					/* translators: %s: invalid prompt name returned by filter */
-					__( 'Filter returned invalid MCP prompt name: %s', 'mcp-adapter' ),
+					__( 'Filter returned invalid MCP prompt name: %s', 'saddle' ),
 					is_string( $filtered_name ) ? $filtered_name : gettype( $filtered_name )
 				)
 			);
@@ -504,7 +504,7 @@ class RegisterAbilityAsMcpPrompt {
 				'mcp_prompt_dto_creation_failed',
 				sprintf(
 				/* translators: %s: error message */
-					__( 'Failed to create Prompt DTO for ability %1$s: %2$s', 'mcp-adapter' ),
+					__( 'Failed to create Prompt DTO for ability %1$s: %2$s', 'saddle' ),
 					$ability->get_name(),
 					$e->getMessage()
 				),

--- a/includes/lib/wp-mcp/includes/Domain/Resources/McpResource.php
+++ b/includes/lib/wp-mcp/includes/Domain/Resources/McpResource.php
@@ -187,7 +187,7 @@ final class McpResource implements McpComponentInterface {
 				'mcp_resource_dto_creation_failed',
 				sprintf(
 				/* translators: %s: error message */
-					__( 'Failed to create Resource DTO: %s', 'mcp-adapter' ),
+					__( 'Failed to create Resource DTO: %s', 'saddle' ),
 					$e->getMessage()
 				),
 				array( 'exception' => $e )

--- a/includes/lib/wp-mcp/includes/Domain/Resources/McpResourceValidator.php
+++ b/includes/lib/wp-mcp/includes/Domain/Resources/McpResourceValidator.php
@@ -38,7 +38,7 @@ class McpResourceValidator {
 			$error_message  = $context ? "[{$context}] " : '';
 			$error_message .= sprintf(
 			/* translators: %s: comma-separated list of validation errors */
-				__( 'Resource validation failed: %s', 'mcp-adapter' ),
+				__( 'Resource validation failed: %s', 'saddle' ),
 				implode( ', ', $validation_errors )
 			);
 			return new WP_Error( 'mcp_resource_validation_failed', esc_html( $error_message ) );
@@ -59,13 +59,13 @@ class McpResourceValidator {
 
 		// Validate URI.
 		if ( ! McpValidator::validate_resource_uri( $resource_dto->getUri() ) ) {
-			$errors[] = __( 'Resource URI must be a valid URI string', 'mcp-adapter' );
+			$errors[] = __( 'Resource URI must be a valid URI string', 'saddle' );
 		}
 
 		// Validate the MIME type if present.
 		$mime_type = $resource_dto->getMimeType();
 		if ( $mime_type && ! McpValidator::validate_mime_type( $mime_type ) ) {
-			$errors[] = __( 'Resource MIME type is invalid', 'mcp-adapter' );
+			$errors[] = __( 'Resource MIME type is invalid', 'saddle' );
 		}
 
 		// Validate icons if present.
@@ -89,7 +89,7 @@ class McpResourceValidator {
 				'mcp_resource_validation_failed',
 				sprintf(
 				/* translators: %s: list of validation errors */
-					__( 'Resource validation failed: %s', 'mcp-adapter' ),
+					__( 'Resource validation failed: %s', 'saddle' ),
 					implode( '; ', $errors )
 				)
 			);
@@ -131,9 +131,9 @@ class McpResourceValidator {
 
 		// Validate the required URI field.
 		if ( empty( $resource_data['uri'] ) || ! is_string( $resource_data['uri'] ) ) {
-			$errors[] = __( 'Resource URI is required and must be a non-empty string', 'mcp-adapter' );
+			$errors[] = __( 'Resource URI is required and must be a non-empty string', 'saddle' );
 		} elseif ( ! McpValidator::validate_resource_uri( $resource_data['uri'] ) ) {
-			$errors[] = __( 'Resource URI must be a valid URI format', 'mcp-adapter' );
+			$errors[] = __( 'Resource URI must be a valid URI format', 'saddle' );
 		}
 
 		// Validate content: at least one of text/blob must be present and correctly typed.
@@ -145,28 +145,28 @@ class McpResourceValidator {
 		$has_blob = $has_blob_key && is_string( $resource_data['blob'] );
 
 		if ( ! $has_text && ! $has_blob ) {
-			$errors[] = __( 'Resource contents must include at least one of: text (string) or blob (base64 string)', 'mcp-adapter' );
+			$errors[] = __( 'Resource contents must include at least one of: text (string) or blob (base64 string)', 'saddle' );
 		}
 
 		if ( $has_text_key && ! is_string( $resource_data['text'] ) ) {
-			$errors[] = __( 'Resource text content must be a string when provided', 'mcp-adapter' );
+			$errors[] = __( 'Resource text content must be a string when provided', 'saddle' );
 		}
 
 		if ( $has_blob_key && ! is_string( $resource_data['blob'] ) ) {
-			$errors[] = __( 'Resource blob content must be a string when provided', 'mcp-adapter' );
+			$errors[] = __( 'Resource blob content must be a string when provided', 'saddle' );
 		}
 
 		// Validate blob content if present and typed.
 		if ( $has_blob && ! McpValidator::validate_base64( $resource_data['blob'] ) ) {
-			$errors[] = __( 'Resource blob content must be valid base64-encoded data', 'mcp-adapter' );
+			$errors[] = __( 'Resource blob content must be valid base64-encoded data', 'saddle' );
 		}
 
 		// Validate mimeType if present (optional).
 		if ( isset( $resource_data['mimeType'] ) ) {
 			if ( ! is_string( $resource_data['mimeType'] ) ) {
-				$errors[] = __( 'Resource mimeType must be a string if provided', 'mcp-adapter' );
+				$errors[] = __( 'Resource mimeType must be a string if provided', 'saddle' );
 			} elseif ( ! McpValidator::validate_mime_type( $resource_data['mimeType'] ) ) {
-				$errors[] = __( 'Resource mimeType must be a valid MIME type format', 'mcp-adapter' );
+				$errors[] = __( 'Resource mimeType must be a valid MIME type format', 'saddle' );
 			}
 		}
 
@@ -188,7 +188,7 @@ class McpResourceValidator {
 				foreach ( $error_group['errors'] as $error ) {
 					$errors[] = sprintf(
 					/* translators: 1: icon index, 2: error message */
-						__( 'Icon at index %1$d: %2$s', 'mcp-adapter' ),
+						__( 'Icon at index %1$d: %2$s', 'saddle' ),
 						$error_group['index'],
 						$error
 					);

--- a/includes/lib/wp-mcp/includes/Domain/Resources/RegisterAbilityAsMcpResource.php
+++ b/includes/lib/wp-mcp/includes/Domain/Resources/RegisterAbilityAsMcpResource.php
@@ -184,7 +184,7 @@ class RegisterAbilityAsMcpResource {
 						self::class . '::get_data',
 						sprintf(
 						/* translators: 1: ability name, 2: validation errors */
-							__( 'Invalid annotations for resource ability "%1$s" will be dropped: %2$s', 'mcp-adapter' ),
+							__( 'Invalid annotations for resource ability "%1$s" will be dropped: %2$s', 'saddle' ),
 							$this->ability->get_name(),
 							implode( '; ', $validation_errors )
 						),
@@ -238,7 +238,7 @@ class RegisterAbilityAsMcpResource {
 				'resource_uri_not_found',
 				sprintf(
 				/* translators: %s: ability name */
-					__( "Resource URI not found in ability meta for '%s'. URI must be provided at 'mcp.uri'.", 'mcp-adapter' ),
+					__( "Resource URI not found in ability meta for '%s'. URI must be provided at 'mcp.uri'.", 'saddle' ),
 					$this->ability->get_name()
 				)
 			);
@@ -252,7 +252,7 @@ class RegisterAbilityAsMcpResource {
 				'resource_uri_invalid',
 				sprintf(
 				/* translators: 1: ability name, 2: invalid URI */
-					__( "Invalid resource URI '%2\$s' for ability '%1\$s'. URI must be RFC 3986 compliant with a scheme.", 'mcp-adapter' ),
+					__( "Invalid resource URI '%2\$s' for ability '%1\$s'. URI must be RFC 3986 compliant with a scheme.", 'saddle' ),
 					$this->ability->get_name(),
 					$uri
 				)
@@ -275,7 +275,7 @@ class RegisterAbilityAsMcpResource {
 				'mcp_resource_uri_filter_invalid',
 				sprintf(
 				/* translators: %s: invalid URI returned by filter */
-					__( 'Filter returned invalid MCP resource URI: %s', 'mcp-adapter' ),
+					__( 'Filter returned invalid MCP resource URI: %s', 'saddle' ),
 					is_string( $filtered_uri ) ? $filtered_uri : gettype( $filtered_uri )
 				)
 			);
@@ -317,7 +317,7 @@ class RegisterAbilityAsMcpResource {
 					__METHOD__,
 					sprintf(
 					/* translators: 1: deprecated meta key, 2: new meta key path */
-						__( 'Ability meta key "%1$s" is deprecated. Use "mcp.%1$s" instead.', 'mcp-adapter' ),
+						__( 'Ability meta key "%1$s" is deprecated. Use "mcp.%1$s" instead.', 'saddle' ),
 						$key
 					),
 					array( 'deprecated_key' => $key )
@@ -454,7 +454,7 @@ class RegisterAbilityAsMcpResource {
 				'mcp_resource_dto_creation_failed',
 				sprintf(
 				/* translators: %s: error message */
-					__( 'Failed to create Resource DTO for ability %1$s: %2$s', 'mcp-adapter' ),
+					__( 'Failed to create Resource DTO for ability %1$s: %2$s', 'saddle' ),
 					$ability->get_name(),
 					$e->getMessage()
 				),

--- a/includes/lib/wp-mcp/includes/Domain/Tools/McpTool.php
+++ b/includes/lib/wp-mcp/includes/Domain/Tools/McpTool.php
@@ -180,7 +180,7 @@ final class McpTool implements McpComponentInterface {
 				'mcp_tool_dto_creation_failed',
 				sprintf(
 				/* translators: %s: error message */
-					__( 'Failed to create Tool DTO: %s', 'mcp-adapter' ),
+					__( 'Failed to create Tool DTO: %s', 'saddle' ),
 					$e->getMessage()
 				),
 				array( 'exception' => $e )

--- a/includes/lib/wp-mcp/includes/Domain/Tools/McpToolValidator.php
+++ b/includes/lib/wp-mcp/includes/Domain/Tools/McpToolValidator.php
@@ -51,7 +51,7 @@ class McpToolValidator {
 			$error_message  = $context ? "[$context] " : '';
 			$error_message .= sprintf(
 			/* translators: %s: comma-separated list of validation errors */
-				__( 'Tool validation failed: %s', 'mcp-adapter' ),
+				__( 'Tool validation failed: %s', 'saddle' ),
 				implode( ', ', $validation_errors )
 			);
 			return new WP_Error( 'mcp_tool_validation_failed', esc_html( $error_message ) );
@@ -84,7 +84,7 @@ class McpToolValidator {
 
 		// Validate name (required, 1-128 chars, alphanumeric + _.-).
 		if ( ! McpValidator::validate_name( $tool->getName() ) ) {
-			$errors[] = __( 'Tool name must be 1-128 characters and contain only [A-Za-z0-9_.-]', 'mcp-adapter' );
+			$errors[] = __( 'Tool name must be 1-128 characters and contain only [A-Za-z0-9_.-]', 'saddle' );
 		}
 
 		// Validate icons if present.
@@ -137,7 +137,7 @@ class McpToolValidator {
 				'mcp_tool_validation_failed',
 				sprintf(
 				/* translators: %s: list of validation errors */
-					__( 'Tool validation failed: %s', 'mcp-adapter' ),
+					__( 'Tool validation failed: %s', 'saddle' ),
 					implode( '; ', $errors )
 				)
 			);
@@ -159,12 +159,12 @@ class McpToolValidator {
 
 		// Check the required field: name.
 		if ( empty( $tool_data['name'] ) || ! is_string( $tool_data['name'] ) || ! McpValidator::validate_name( $tool_data['name'] ) ) {
-			$errors[] = __( 'Tool name is required and must only contain letters, numbers, hyphens (-), underscores (_), and dots (.), and be 128 characters or less', 'mcp-adapter' );
+			$errors[] = __( 'Tool name is required and must only contain letters, numbers, hyphens (-), underscores (_), and dots (.), and be 128 characters or less', 'saddle' );
 		}
 
 		// Description is optional per MCP 2025-11-25 spec, but validate if present.
 		if ( isset( $tool_data['description'] ) && ! is_string( $tool_data['description'] ) ) {
-			$errors[] = __( 'Tool description must be a string if provided', 'mcp-adapter' );
+			$errors[] = __( 'Tool description must be a string if provided', 'saddle' );
 		}
 
 		// Validate inputSchema (required field).
@@ -175,7 +175,7 @@ class McpToolValidator {
 
 		// Check optional fields if present.
 		if ( isset( $tool_data['title'] ) && ! is_string( $tool_data['title'] ) ) {
-			$errors[] = __( 'Tool title must be a string if provided', 'mcp-adapter' );
+			$errors[] = __( 'Tool title must be a string if provided', 'saddle' );
 		}
 
 		// Validate outputSchema (optional field).
@@ -205,7 +205,7 @@ class McpToolValidator {
 		// Validate annotations structure if present (tool-specific annotations only).
 		if ( isset( $tool_data['annotations'] ) ) {
 			if ( ! is_array( $tool_data['annotations'] ) ) {
-				$errors[] = __( 'Tool annotations must be an array if provided', 'mcp-adapter' );
+				$errors[] = __( 'Tool annotations must be an array if provided', 'saddle' );
 			} else {
 				// Validate tool-specific annotations (readOnlyHint, destructiveHint, etc.).
 				$tool_annotation_errors = self::get_tool_annotation_validation_errors( $tool_data['annotations'] );
@@ -217,7 +217,7 @@ class McpToolValidator {
 
 		// Validate _meta (optional field).
 		if ( isset( $tool_data['_meta'] ) && ! is_array( $tool_data['_meta'] ) ) {
-			$errors[] = __( 'Tool _meta must be an object/array if provided', 'mcp-adapter' );
+			$errors[] = __( 'Tool _meta must be an object/array if provided', 'saddle' );
 		}
 
 		return $errors;
@@ -242,7 +242,7 @@ class McpToolValidator {
 			return array(
 				sprintf(
 				/* translators: %s: field name (inputSchema or outputSchema) */
-					__( 'Tool %s must be a valid JSON schema object', 'mcp-adapter' ),
+					__( 'Tool %s must be a valid JSON schema object', 'saddle' ),
 					$field_name
 				),
 			);
@@ -254,13 +254,13 @@ class McpToolValidator {
 		if ( ! isset( $schema['type'] ) ) {
 			$errors[] = sprintf(
 			/* translators: %s: field name */
-				__( 'Tool %s must specify a root type of \'object\'', 'mcp-adapter' ),
+				__( 'Tool %s must specify a root type of \'object\'', 'saddle' ),
 				$field_name
 			);
 		} elseif ( ! is_string( $schema['type'] ) || 'object' !== $schema['type'] ) {
 			$errors[] = sprintf(
 			/* translators: %s: field name */
-				__( 'Tool %s root type must be \'object\'', 'mcp-adapter' ),
+				__( 'Tool %s root type must be \'object\'', 'saddle' ),
 				$field_name
 			);
 		}
@@ -269,7 +269,7 @@ class McpToolValidator {
 		if ( isset( $schema['properties'] ) && ! is_array( $schema['properties'] ) ) {
 			$errors[] = sprintf(
 			/* translators: %s: field name */
-				__( 'Tool %s properties must be an object/array', 'mcp-adapter' ),
+				__( 'Tool %s properties must be an object/array', 'saddle' ),
 				$field_name
 			);
 		}
@@ -278,7 +278,7 @@ class McpToolValidator {
 		if ( isset( $schema['required'] ) && ! is_array( $schema['required'] ) ) {
 			$errors[] = sprintf(
 			/* translators: %s: field name */
-				__( 'Tool %s required field must be an array', 'mcp-adapter' ),
+				__( 'Tool %s required field must be an array', 'saddle' ),
 				$field_name
 			);
 		}
@@ -294,7 +294,7 @@ class McpToolValidator {
 				if ( ! is_array( $property ) ) {
 					$errors[] = sprintf(
 					/* translators: %1$s: field name, %2$s: property name */
-						__( 'Tool %1$s property \'%2$s\' must be an object', 'mcp-adapter' ),
+						__( 'Tool %1$s property \'%2$s\' must be an object', 'saddle' ),
 						$field_name,
 						$property_name
 					);
@@ -309,7 +309,7 @@ class McpToolValidator {
 				// If the type is neither string nor array, it's invalid.
 				$errors[] = sprintf(
 				/* translators: %1$s: field name, %2$s: property name */
-					__( 'Tool %1$s property \'%2$s\' type must be a string or array of strings (union type)', 'mcp-adapter' ),
+					__( 'Tool %1$s property \'%2$s\' type must be a string or array of strings (union type)', 'saddle' ),
 					$field_name,
 					$property_name
 				);
@@ -322,7 +322,7 @@ class McpToolValidator {
 				if ( ! is_string( $required_field ) ) {
 					$errors[] = sprintf(
 					/* translators: %s: field name */
-						__( 'Tool %s required field names must be strings', 'mcp-adapter' ),
+						__( 'Tool %s required field names must be strings', 'saddle' ),
 						$field_name
 					);
 					continue;
@@ -335,7 +335,7 @@ class McpToolValidator {
 
 				$errors[] = sprintf(
 				/* translators: %1$s: field name, %2$s: required field */
-					__( 'Tool %1$s required field \'%2$s\' does not exist in properties', 'mcp-adapter' ),
+					__( 'Tool %1$s required field \'%2$s\' does not exist in properties', 'saddle' ),
 					$field_name,
 					$required_field
 				);
@@ -354,7 +354,7 @@ class McpToolValidator {
 	 */
 	private static function get_icons_validation_errors( $icons ): array {
 		if ( ! is_array( $icons ) ) {
-			return array( __( 'Tool icons must be an array if provided', 'mcp-adapter' ) );
+			return array( __( 'Tool icons must be an array if provided', 'saddle' ) );
 		}
 
 		$icons_result = McpValidator::validate_icons_array( $icons, false );
@@ -377,7 +377,7 @@ class McpToolValidator {
 				foreach ( $error_group['errors'] as $error ) {
 					$errors[] = sprintf(
 					/* translators: 1: icon index, 2: error message */
-						__( 'Icon at index %1$d: %2$s', 'mcp-adapter' ),
+						__( 'Icon at index %1$d: %2$s', 'saddle' ),
 						$error_group['index'],
 						$error
 					);
@@ -400,7 +400,7 @@ class McpToolValidator {
 	 */
 	public static function get_execution_validation_errors( $execution ): array {
 		if ( ! is_array( $execution ) ) {
-			return array( __( 'Tool execution must be an object/array if provided', 'mcp-adapter' ) );
+			return array( __( 'Tool execution must be an object/array if provided', 'saddle' ) );
 		}
 
 		$errors = array();
@@ -408,11 +408,11 @@ class McpToolValidator {
 		// Validate taskSupport if present.
 		if ( isset( $execution['taskSupport'] ) ) {
 			if ( ! is_string( $execution['taskSupport'] ) ) {
-				$errors[] = __( 'Tool execution taskSupport must be a string', 'mcp-adapter' );
+				$errors[] = __( 'Tool execution taskSupport must be a string', 'saddle' );
 			} elseif ( ! in_array( $execution['taskSupport'], self::$valid_task_support_values, true ) ) {
 				$errors[] = sprintf(
 				/* translators: %s: comma-separated list of valid values */
-					__( 'Tool execution taskSupport must be one of: %s', 'mcp-adapter' ),
+					__( 'Tool execution taskSupport must be one of: %s', 'saddle' ),
 					implode( ', ', self::$valid_task_support_values )
 				);
 			}
@@ -447,7 +447,7 @@ class McpToolValidator {
 					if ( ! is_bool( $value ) ) {
 						$errors[] = sprintf(
 						/* translators: %s: annotation field name */
-							__( 'Tool annotation field %s must be a boolean', 'mcp-adapter' ),
+							__( 'Tool annotation field %s must be a boolean', 'saddle' ),
 							$field
 						);
 					}
@@ -457,7 +457,7 @@ class McpToolValidator {
 					if ( ! is_string( $value ) ) {
 						$errors[] = sprintf(
 						/* translators: %s: annotation field name */
-							__( 'Tool annotation field %s must be a string', 'mcp-adapter' ),
+							__( 'Tool annotation field %s must be a string', 'saddle' ),
 							$field
 						);
 						break;
@@ -465,7 +465,7 @@ class McpToolValidator {
 					if ( empty( trim( $value ) ) ) {
 						$errors[] = sprintf(
 						/* translators: %s: annotation field name */
-							__( 'Tool annotation field %s must be a non-empty string', 'mcp-adapter' ),
+							__( 'Tool annotation field %s must be a non-empty string', 'saddle' ),
 							$field
 						);
 					}

--- a/includes/lib/wp-mcp/includes/Domain/Tools/RegisterAbilityAsMcpTool.php
+++ b/includes/lib/wp-mcp/includes/Domain/Tools/RegisterAbilityAsMcpTool.php
@@ -72,7 +72,7 @@ class RegisterAbilityAsMcpTool {
 				'mcp_tool_dto_creation_failed',
 				sprintf(
 				/* translators: %s: error message */
-					__( 'Failed to create Tool DTO for ability %1$s: %2$s', 'mcp-adapter' ),
+					__( 'Failed to create Tool DTO for ability %1$s: %2$s', 'saddle' ),
 					$ability->get_name(),
 					$e->getMessage()
 				),
@@ -230,7 +230,7 @@ class RegisterAbilityAsMcpTool {
 				'mcp_tool_name_filter_invalid',
 				sprintf(
 				/* translators: %s: invalid tool name returned by filter */
-					__( 'Filter returned invalid MCP tool name: %s', 'mcp-adapter' ),
+					__( 'Filter returned invalid MCP tool name: %s', 'saddle' ),
 					is_string( $filtered_name ) ? $filtered_name : gettype( $filtered_name )
 				)
 			);

--- a/includes/lib/wp-mcp/includes/Domain/Utils/McpNameSanitizer.php
+++ b/includes/lib/wp-mcp/includes/Domain/Utils/McpNameSanitizer.php
@@ -103,7 +103,7 @@ class McpNameSanitizer {
 				'mcp_name_invalid',
 				sprintf(
 				/* translators: %s: original ability name */
-					__( 'Unable to derive valid MCP name from: %s', 'mcp-adapter' ),
+					__( 'Unable to derive valid MCP name from: %s', 'saddle' ),
 					$original
 				)
 			);

--- a/includes/lib/wp-mcp/includes/Domain/Utils/McpValidator.php
+++ b/includes/lib/wp-mcp/includes/Domain/Utils/McpValidator.php
@@ -139,7 +139,7 @@ class McpValidator {
 			if ( ! is_array( $icon ) ) {
 				$all_errors[] = array(
 					'index'  => $index,
-					'errors' => array( __( 'Icon must be an array', 'mcp-adapter' ) ),
+					'errors' => array( __( 'Icon must be an array', 'saddle' ) ),
 				);
 				continue;
 			}
@@ -193,21 +193,21 @@ class McpValidator {
 
 		// src is required.
 		if ( ! isset( $icon['src'] ) ) {
-			$errors[] = __( 'Icon must have a src field', 'mcp-adapter' );
+			$errors[] = __( 'Icon must have a src field', 'saddle' );
 		} elseif ( ! is_string( $icon['src'] ) ) {
-			$errors[] = __( 'Icon src must be a string', 'mcp-adapter' );
+			$errors[] = __( 'Icon src must be a string', 'saddle' );
 		} elseif ( ! self::validate_icon_src( $icon['src'] ) ) {
-			$errors[] = __( 'Icon src must be a valid URL (http/https) or data: URI', 'mcp-adapter' );
+			$errors[] = __( 'Icon src must be a valid URL (http/https) or data: URI', 'saddle' );
 		}
 
 		// mimeType is optional but must be valid if present.
 		if ( isset( $icon['mimeType'] ) ) {
 			if ( ! is_string( $icon['mimeType'] ) ) {
-				$errors[] = __( 'Icon mimeType must be a string', 'mcp-adapter' );
+				$errors[] = __( 'Icon mimeType must be a string', 'saddle' );
 			} elseif ( ! self::validate_icon_mime_type( $icon['mimeType'] ) ) {
 				$errors[] = sprintf(
 				/* translators: %s: comma-separated list of allowed MIME types */
-					__( 'Icon mimeType must be one of: %s', 'mcp-adapter' ),
+					__( 'Icon mimeType must be one of: %s', 'saddle' ),
 					implode( ', ', self::$allowed_icon_mime_types )
 				);
 			}
@@ -216,19 +216,19 @@ class McpValidator {
 		// sizes is optional but must be valid if present.
 		if ( isset( $icon['sizes'] ) ) {
 			if ( ! is_array( $icon['sizes'] ) ) {
-				$errors[] = __( 'Icon sizes must be an array', 'mcp-adapter' );
+				$errors[] = __( 'Icon sizes must be an array', 'saddle' );
 			} else {
 				foreach ( $icon['sizes'] as $index => $size ) {
 					if ( ! is_string( $size ) ) {
 						$errors[] = sprintf(
 						/* translators: %d: array index */
-							__( 'Icon size at index %d must be a string', 'mcp-adapter' ),
+							__( 'Icon size at index %d must be a string', 'saddle' ),
 							$index
 						);
 					} elseif ( ! self::validate_icon_size( $size ) ) {
 						$errors[] = sprintf(
 						/* translators: 1: size value, 2: array index */
-							__( 'Icon size "%1$s" at index %2$d must be in WxH format (e.g., "48x48") or "any"', 'mcp-adapter' ),
+							__( 'Icon size "%1$s" at index %2$d must be in WxH format (e.g., "48x48") or "any"', 'saddle' ),
 							$size,
 							$index
 						);
@@ -240,9 +240,9 @@ class McpValidator {
 		// theme is optional but must be valid if present.
 		if ( isset( $icon['theme'] ) ) {
 			if ( ! is_string( $icon['theme'] ) ) {
-				$errors[] = __( 'Icon theme must be a string', 'mcp-adapter' );
+				$errors[] = __( 'Icon theme must be a string', 'saddle' );
 			} elseif ( ! self::validate_icon_theme( $icon['theme'] ) ) {
-				$errors[] = __( 'Icon theme must be "light" or "dark"', 'mcp-adapter' );
+				$errors[] = __( 'Icon theme must be "light" or "dark"', 'saddle' );
 			}
 		}
 
@@ -366,31 +366,31 @@ class McpValidator {
 			switch ( $field ) {
 				case 'audience':
 					if ( ! is_array( $value ) ) {
-						$errors[] = __( 'Annotation field audience must be an array', 'mcp-adapter' );
+						$errors[] = __( 'Annotation field audience must be an array', 'saddle' );
 						break;
 					}
 					if ( ! self::validate_roles_array( $value ) ) {
-						$errors[] = __( 'Annotation field audience must contain only valid roles ("user" or "assistant")', 'mcp-adapter' );
+						$errors[] = __( 'Annotation field audience must contain only valid roles ("user" or "assistant")', 'saddle' );
 					}
 					break;
 
 				case 'lastModified':
 					if ( ! is_string( $value ) || empty( trim( $value ) ) ) {
-						$errors[] = __( 'Annotation field lastModified must be a non-empty string', 'mcp-adapter' );
+						$errors[] = __( 'Annotation field lastModified must be a non-empty string', 'saddle' );
 						break;
 					}
 					if ( ! self::validate_iso8601_timestamp( trim( $value ) ) ) {
-						$errors[] = __( 'Annotation field lastModified must be a valid ISO 8601 timestamp', 'mcp-adapter' );
+						$errors[] = __( 'Annotation field lastModified must be a valid ISO 8601 timestamp', 'saddle' );
 					}
 					break;
 
 				case 'priority':
 					if ( ! is_numeric( $value ) ) {
-						$errors[] = __( 'Annotation field priority must be a number', 'mcp-adapter' );
+						$errors[] = __( 'Annotation field priority must be a number', 'saddle' );
 						break;
 					}
 					if ( ! self::validate_priority( $value ) ) {
-						$errors[] = __( 'Annotation field priority must be between 0.0 and 1.0', 'mcp-adapter' );
+						$errors[] = __( 'Annotation field priority must be between 0.0 and 1.0', 'saddle' );
 					}
 					break;
 

--- a/includes/lib/wp-mcp/includes/Handlers/Tools/ToolsHandler.php
+++ b/includes/lib/wp-mcp/includes/Handlers/Tools/ToolsHandler.php
@@ -147,7 +147,7 @@ class ToolsHandler {
 
 			$permission = $mcp_tool->check_permission( $args );
 			if ( true !== $permission ) {
-				$error_message = __( 'Permission denied', 'mcp-adapter' );
+				$error_message = __( 'Permission denied', 'saddle' );
 				if ( is_wp_error( $permission ) ) {
 					$error_message = $permission->get_error_message();
 

--- a/includes/lib/wp-mcp/includes/Infrastructure/ErrorHandling/McpErrorFactory.php
+++ b/includes/lib/wp-mcp/includes/Infrastructure/ErrorHandling/McpErrorFactory.php
@@ -53,7 +53,7 @@ class McpErrorFactory {
 	 * @return \WP\McpSchema\Common\JsonRpc\DTO\JSONRPCErrorResponse
 	 */
 	public static function parse_error( $id, string $details = '' ): JSONRPCErrorResponse {
-		$message = __( 'Parse error', 'mcp-adapter' );
+		$message = __( 'Parse error', 'saddle' );
 		if ( $details ) {
 			$message .= ': ' . $details;
 		}
@@ -114,7 +114,7 @@ class McpErrorFactory {
 			self::METHOD_NOT_FOUND,
 			sprintf(
 			/* translators: %s: method name */
-				__( 'Method not found: %s', 'mcp-adapter' ),
+				__( 'Method not found: %s', 'saddle' ),
 				$method
 			)
 		);
@@ -129,7 +129,7 @@ class McpErrorFactory {
 	 * @return \WP\McpSchema\Common\JsonRpc\DTO\JSONRPCErrorResponse
 	 */
 	public static function invalid_params( $id, string $details = '' ): JSONRPCErrorResponse {
-		$message = __( 'Invalid params', 'mcp-adapter' );
+		$message = __( 'Invalid params', 'saddle' );
 		if ( $details ) {
 			$message .= ': ' . $details;
 		}
@@ -146,7 +146,7 @@ class McpErrorFactory {
 	 * @return \WP\McpSchema\Common\JsonRpc\DTO\JSONRPCErrorResponse
 	 */
 	public static function internal_error( $id, string $details = '' ): JSONRPCErrorResponse {
-		$message = __( 'Internal error', 'mcp-adapter' );
+		$message = __( 'Internal error', 'saddle' );
 		if ( $details ) {
 			$message .= ': ' . $details;
 		}
@@ -165,7 +165,7 @@ class McpErrorFactory {
 		return self::create_error_response(
 			$id,
 			self::SERVER_ERROR,
-			__( 'MCP functionality is currently disabled', 'mcp-adapter' )
+			__( 'MCP functionality is currently disabled', 'saddle' )
 		);
 	}
 
@@ -183,7 +183,7 @@ class McpErrorFactory {
 			self::INVALID_PARAMS,
 			sprintf(
 			/* translators: %s: validation details */
-				__( 'Validation error: %s', 'mcp-adapter' ),
+				__( 'Validation error: %s', 'saddle' ),
 				$details
 			)
 		);
@@ -203,7 +203,7 @@ class McpErrorFactory {
 			self::INVALID_PARAMS,
 			sprintf(
 			/* translators: %s: parameter name */
-				__( 'Missing required parameter: %s', 'mcp-adapter' ),
+				__( 'Missing required parameter: %s', 'saddle' ),
 				$parameter
 			)
 		);
@@ -223,7 +223,7 @@ class McpErrorFactory {
 			self::RESOURCE_NOT_FOUND,
 			sprintf(
 			/* translators: %s: resource identifier */
-				__( 'Resource not found: %s', 'mcp-adapter' ),
+				__( 'Resource not found: %s', 'saddle' ),
 				$resource_uri
 			)
 		);
@@ -243,7 +243,7 @@ class McpErrorFactory {
 			self::TOOL_NOT_FOUND,
 			sprintf(
 			/* translators: %s: tool name */
-				__( 'Tool not found: %s', 'mcp-adapter' ),
+				__( 'Tool not found: %s', 'saddle' ),
 				$tool
 			)
 		);
@@ -263,7 +263,7 @@ class McpErrorFactory {
 			self::TOOL_NOT_FOUND,
 			sprintf(
 			/* translators: %s: ability name */
-				__( 'Ability not found: %s', 'mcp-adapter' ),
+				__( 'Ability not found: %s', 'saddle' ),
 				$ability
 			)
 		);
@@ -283,7 +283,7 @@ class McpErrorFactory {
 			self::PROMPT_NOT_FOUND,
 			sprintf(
 			/* translators: %s: prompt name */
-				__( 'Prompt not found: %s', 'mcp-adapter' ),
+				__( 'Prompt not found: %s', 'saddle' ),
 				$prompt
 			)
 		);
@@ -301,7 +301,7 @@ class McpErrorFactory {
 	 * @return \WP\McpSchema\Common\JsonRpc\DTO\JSONRPCErrorResponse
 	 */
 	public static function session_not_found( $id, string $details = '' ): JSONRPCErrorResponse {
-		$message = __( 'Session not found', 'mcp-adapter' );
+		$message = __( 'Session not found', 'saddle' );
 		if ( $details ) {
 			$message .= ': ' . $details;
 		}
@@ -318,7 +318,7 @@ class McpErrorFactory {
 	 * @return \WP\McpSchema\Common\JsonRpc\DTO\JSONRPCErrorResponse
 	 */
 	public static function permission_denied( $id, string $details = '' ): JSONRPCErrorResponse {
-		$message = __( 'Permission denied', 'mcp-adapter' );
+		$message = __( 'Permission denied', 'saddle' );
 		if ( $details ) {
 			$message .= ': ' . $details;
 		}
@@ -335,7 +335,7 @@ class McpErrorFactory {
 	 * @return \WP\McpSchema\Common\JsonRpc\DTO\JSONRPCErrorResponse
 	 */
 	public static function unauthorized( $id, string $details = '' ): JSONRPCErrorResponse {
-		$message = __( 'Unauthorized', 'mcp-adapter' );
+		$message = __( 'Unauthorized', 'saddle' );
 		if ( $details ) {
 			$message .= ': ' . $details;
 		}
@@ -430,7 +430,7 @@ class McpErrorFactory {
 	 */
 	public static function validate_jsonrpc_message( $message ) {
 		if ( ! is_array( $message ) ) {
-			return self::invalid_request( null, __( 'Message must be a JSON object', 'mcp-adapter' ) );
+			return self::invalid_request( null, __( 'Message must be a JSON object', 'saddle' ) );
 		}
 
 		// Must have jsonrpc field with value "2.0".
@@ -439,7 +439,7 @@ class McpErrorFactory {
 				null,
 				sprintf(
 				/* translators: %s: JSON-RPC version */
-					__( 'jsonrpc version must be "%s"', 'mcp-adapter' ),
+					__( 'jsonrpc version must be "%s"', 'saddle' ),
 					McpConstants::JSONRPC_VERSION
 				)
 			);
@@ -450,12 +450,12 @@ class McpErrorFactory {
 		$is_response                = isset( $message['result'] ) || isset( $message['error'] );
 
 		if ( ! $is_request_or_notification && ! $is_response ) {
-			return self::invalid_request( null, __( 'Message must have either method or result/error field', 'mcp-adapter' ) );
+			return self::invalid_request( null, __( 'Message must have either method or result/error field', 'saddle' ) );
 		}
 
 		// Responses must have an id field.
 		if ( $is_response && ! isset( $message['id'] ) ) {
-			return self::invalid_request( null, __( 'Response messages must have an id field', 'mcp-adapter' ) );
+			return self::invalid_request( null, __( 'Response messages must have an id field', 'saddle' ) );
 		}
 
 		return true;
@@ -470,7 +470,7 @@ class McpErrorFactory {
 	 * @return \WP\McpSchema\Common\JsonRpc\DTO\JSONRPCErrorResponse
 	 */
 	public static function invalid_request( $id, string $details = '' ): JSONRPCErrorResponse {
-		$message = __( 'Invalid Request', 'mcp-adapter' );
+		$message = __( 'Invalid Request', 'saddle' );
 		if ( $details ) {
 			$message .= ': ' . $details;
 		}

--- a/includes/lib/wp-mcp/includes/Plugin.php
+++ b/includes/lib/wp-mcp/includes/Plugin.php
@@ -73,7 +73,7 @@ final class Plugin {
 				'admin_notices',
 				static function () {
 					wp_admin_notice(
-						__( 'Abilities API not available (wp_register_ability function not found)', 'mcp-adapter' ),
+						__( 'Abilities API not available (wp_register_ability function not found)', 'saddle' ),
 						array(
 							'type'    => 'error',
 							'dismiss' => false,
@@ -96,7 +96,7 @@ final class Plugin {
 			__FUNCTION__,
 			sprintf(
 			// translators: %s: Class name.
-				esc_html__( 'The %s class should not be cloned.', 'mcp-adapter' ),
+				esc_html__( 'The %s class should not be cloned.', 'saddle' ),
 				esc_html( self::class ),
 			),
 			'0.1.0'
@@ -111,7 +111,7 @@ final class Plugin {
 			__FUNCTION__,
 			sprintf(
 			// translators: %s: Class name.
-				esc_html__( 'De-serializing instances of %s is not allowed.', 'mcp-adapter' ),
+				esc_html__( 'De-serializing instances of %s is not allowed.', 'saddle' ),
 				esc_html( self::class ),
 			),
 			'0.1.0'

--- a/includes/lib/wp-mcp/includes/Transport/Infrastructure/RequestRouter.php
+++ b/includes/lib/wp-mcp/includes/Transport/Infrastructure/RequestRouter.php
@@ -331,7 +331,7 @@ class RequestRouter {
 				return McpErrorFactory::create_error_response(
 					$request_id,
 					isset( $error['code'] ) ? (int) $error['code'] : McpErrorFactory::INTERNAL_ERROR,
-					(string) ( $error['message'] ?? __( 'Failed to create session', 'mcp-adapter' ) ),
+					(string) ( $error['message'] ?? __( 'Failed to create session', 'saddle' ) ),
 					$error['data'] ?? null
 				);
 			}

--- a/readme.txt
+++ b/readme.txt
@@ -1,4 +1,4 @@
-=== Saddle – Control WordPress with AI (MCP Server) ===
+=== Saddle – Control Your Site with AI (MCP Server) ===
 Contributors: badhonrocks
 Tags: mcp, ai, application passwords, agents, automation
 Requires at least: 6.9

--- a/uninstall.php
+++ b/uninstall.php
@@ -37,9 +37,9 @@ delete_metadata( 'user', 0, 'saddle_admin_theme', '', true );
 delete_metadata( 'user', 0, 'saddle_client_hints', '', true );
 
 // Clear scheduled GC.
-$timestamp = wp_next_scheduled( 'saddle_gc_tokens' );
-if ( $timestamp ) {
-	wp_unschedule_event( $timestamp, 'saddle_gc_tokens' );
+$saddle_gc_timestamp = wp_next_scheduled( 'saddle_gc_tokens' );
+if ( $saddle_gc_timestamp ) {
+	wp_unschedule_event( $saddle_gc_timestamp, 'saddle_gc_tokens' );
 }
 
 // Remove the managed .htaccess block the connection self-check may have added.


### PR DESCRIPTION
Ran the official Plugin Check plugin against the 1.0.0 tree. Fixes the three real findings: the trademarked "WordPress" in the readme title, 147 bundled-lib text-domain mismatches (now 'saddle', identifiers untouched), and an unprefixed global in uninstall.php. Suite green (359 tests). Merge before submitting `dist/saddle-1.0.0.zip`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0133CZhoFPY6BBChDDGEa22Q