### PR TITLE
Agent-guidance fixes: skill bodies uncorrupted, verify honesty, composition rule, native builders

### DIFF
--- a/includes/abilities/site.php
+++ b/includes/abilities/site.php
@@ -767,6 +767,13 @@ class Saddle_Site_Abilities {
 	public static function flush_cache( $input = null ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found -- Fixed ability-callback signature.
 		$flushed = wp_cache_flush();
 
+		/**
+		 * Fires when the owner flushes caches through saddle/flush-cache, so
+		 * add-ons can invalidate their own derived caches (schema indexes,
+		 * context bundles) in the same sweep.
+		 */
+		do_action( 'saddle_flush_cache' );
+
 		Saddle_Log::record_action( 'flush-cache', 'object-cache', __( 'Flushed the object cache.', 'saddle' ) );
 
 		return array(

--- a/includes/abilities/verify.php
+++ b/includes/abilities/verify.php
@@ -94,9 +94,10 @@ class Saddle_Verify_Abilities {
 			),
 			$report,
 			array(
-				'note' => $report['findings']
+				'note'     => $report['findings']
 					? __( 'Fix in order: structural, then "ignored" (echo — that styling never took effect), then errors, then warnings. Addresses match get-blocks/divi-get-page; re-read after structural edits, then re-run verify-page until the score is acceptable.', 'saddle' )
 					: __( 'Everything checked out: the persisted state is structurally sound, every attribute takes effect, and no design violations were found.', 'saddle' ),
+				'coverage' => __( 'This score covers only what the server can verify — persisted structure, attributes, and design rules. It is NOT a visual sign-off: a page can pass every server-side check and still look wrong. Open get-preview-url and judge the real pixels before calling the page done.', 'saddle' ),
 			)
 		);
 	}

--- a/includes/class-saddle-context.php
+++ b/includes/class-saddle-context.php
@@ -157,11 +157,33 @@ class Saddle_Context {
 			}
 
 			if ( ! empty( $builders ) ) {
-				$lines[] = sprintf(
-					/* translators: %s: comma-separated page builder names. */
-					'- ' . __( 'A page builder is active (%s). Pages and posts built with it store their layout as special markup inside the content. Overwriting the "content" field of a builder page with plain text or HTML will BREAK its layout. Prefer leaving builder-built pages alone unless the user explicitly asks you to change one, and even then change only the specific text they mention.', 'saddle' ),
-					implode( ', ', $builders )
-				);
+				/**
+				 * Filter the builders whose pages have DEDICATED saddle tools
+				 * installed (e.g. Saddle Pro registers 'Divi'). Native builders
+				 * get an in-scope note instead of the hands-off warning — an
+				 * addon that ships a full editing surface must not have the
+				 * base plugin telling agents to leave those pages alone.
+				 *
+				 * @param string[] $native Builder labels (as detected, e.g. 'Divi').
+				 */
+				$native  = array_map( 'strval', (array) apply_filters( 'saddle_native_builders', array() ) );
+				$in_tool = array_values( array_intersect( $builders, $native ) );
+				$foreign = array_values( array_diff( $builders, $native ) );
+
+				if ( ! empty( $in_tool ) ) {
+					$lines[] = sprintf(
+						/* translators: %s: comma-separated page builder names. */
+						'- ' . __( 'This site\'s %s pages are edited through dedicated saddle tools — building and restyling them is fully in scope. Use those tools for every change; never write a builder page\'s raw "content" field, which would destroy its layout.', 'saddle' ),
+						implode( ', ', $in_tool )
+					);
+				}
+				if ( ! empty( $foreign ) ) {
+					$lines[] = sprintf(
+						/* translators: %s: comma-separated page builder names. */
+						'- ' . __( 'A page builder is active (%s). Pages and posts built with it store their layout as special markup inside the content. Overwriting the "content" field of a builder page with plain text or HTML will BREAK its layout. Prefer leaving builder-built pages alone unless the user explicitly asks you to change one, and even then change only the specific text they mention.', 'saddle' ),
+						implode( ', ', $foreign )
+					);
+				}
 			}
 			$lines[] = '';
 		}
@@ -261,7 +283,7 @@ class Saddle_Context {
 			__( '# What "designed" means, in numbers', 'saddle' ),
 			'',
 			'- ' . __( 'Type scale: hero/display 44–64px, section headings 28–40px, body 16–18px with line-height 1.5–1.7. Establish a clear step between levels — don\'t set everything near the same size.', 'saddle' ),
-			'- ' . __( 'Line length: keep body text to ~50–75 characters per line (roughly a 600–720px max width for a text column), never full-bleed paragraphs.', 'saddle' ),
+			'- ' . __( 'Line length: keep body text to ~50–75 characters per line (roughly a 600–720px max width for a text column), never full-bleed paragraphs. And CENTER a width-capped text column (or balance it against media) — a max width without centering pins content to the left edge and leaves a dead right half.', 'saddle' ),
 			'- ' . __( 'Spacing on an 8px system (8/16/24/32/48/64/96): generous section padding (~64–96px top/bottom on desktop), consistent gaps within a group, and more space BETWEEN groups than inside them.', 'saddle' ),
 			'- ' . __( 'Color: one dominant neutral background, one text color, and a SINGLE accent used sparingly for emphasis and calls to action. Body text must hit WCAG AA contrast (≥ 4.5:1; ≥ 3:1 for large headings).', 'saddle' ),
 			'- ' . __( 'Rhythm: align to a consistent content width, reuse the same handful of spacing/size steps across the page, and prefer one strong idea per section over dense walls of content.', 'saddle' ),

--- a/includes/class-saddle-skills.php
+++ b/includes/class-saddle-skills.php
@@ -201,7 +201,7 @@ class Saddle_Skills {
 			}
 			$name = sanitize_title( isset( $skill['name'] ) ? (string) $skill['name'] : '' );
 			$desc = sanitize_text_field( isset( $skill['description'] ) ? (string) $skill['description'] : '' );
-			$body = trim( wp_kses( isset( $skill['body'] ) ? (string) $skill['body'] : '', array() ) );
+			$body = self::sanitize_body( isset( $skill['body'] ) ? (string) $skill['body'] : '' );
 			if ( '' === $name || '' === $desc || '' === $body ) {
 				continue;
 			}
@@ -300,12 +300,36 @@ class Saddle_Skills {
 	 */
 
 	/**
+	 * Sanitize a skill body while preserving it byte-for-byte as prose.
+	 *
+	 * Deliberately NOT wp_kses: a skill body is Markdown the agent reads as
+	 * data (served over JSON), never markup a browser renders — and kses
+	 * parses instructional placeholders like `<id>`, `<module>`, or
+	 * `<addr>` as HTML tags and deletes them, silently mutilating the
+	 * playbook before it ever reaches an agent (`post_id=<id>` became
+	 * `post_id=`). The admin UI only ever echoes name/description (both
+	 * sanitize_text_field'd); the body is never printed as HTML. So the
+	 * body keeps its angle brackets and only sheds what could never be
+	 * legitimate prose: invalid UTF-8 and control characters (newlines and
+	 * tabs stay — it's Markdown).
+	 *
+	 * @param string $body Raw body text.
+	 * @return string Sanitized body, trimmed.
+	 */
+	private static function sanitize_body( $body ) {
+		$body = wp_check_invalid_utf8( (string) $body, true );
+		$body = preg_replace( '/[^\P{C}\n\t]/u', '', $body );
+		return trim( (string) $body );
+	}
+
+	/**
 	 * Parse and sanitize raw SKILL.md text into name/description/when/body.
 	 *
 	 * Frontmatter is the simple `key: value` form between `---` fences —
 	 * the same subset every SKILL.md ecosystem actually uses. Unknown keys
-	 * are ignored. The body is stripped of HTML: a skill is Markdown the
-	 * agent reads, never markup a browser renders.
+	 * are ignored. The body is kept verbatim as Markdown (see
+	 * sanitize_body()): a skill is text the agent reads, never markup a
+	 * browser renders, so angle-bracket placeholders must survive.
 	 *
 	 * @param string $markdown Raw content.
 	 * @return array{name:string,description:string,when_to_use:string,body:string}|WP_Error
@@ -345,7 +369,7 @@ class Saddle_Skills {
 			);
 		}
 
-		$body = trim( wp_kses( $m[2], array() ) );
+		$body = self::sanitize_body( $m[2] );
 		if ( '' === $body ) {
 			return new WP_Error(
 				'saddle_skill_empty',

--- a/includes/lint/class-saddle-lint.php
+++ b/includes/lint/class-saddle-lint.php
@@ -81,6 +81,7 @@ class Saddle_Lint {
 			new Saddle_Lint_Rule_Mixed_Accents(),
 			new Saddle_Lint_Rule_Unaligned_Buttons(),
 			new Saddle_Lint_Rule_Section_Padding(),
+			new Saddle_Lint_Rule_Single_Column_Flow(),
 			new Saddle_Lint_Rule_Featured_Plan(),
 			// Accessibility (closed-loop scope); these need the companion
 			// style accessor and stay silent on accessors without it.

--- a/includes/lint/rules/class-rule-single-column-flow.php
+++ b/includes/lint/rules/class-rule-single-column-flow.php
@@ -1,0 +1,122 @@
+<?php
+/**
+ * Lint rule: long single-column flow (the document look).
+ *
+ * @package Saddle
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * A long run of single-column, single-module wrappers reads as a document,
+ * not a designed page: heading row, text row, heading row, text row — each
+ * sibling holding exactly one column holding exactly one leaf module. It is
+ * the most common tell of an agent "filling in" a page instead of composing
+ * one (observed live: 12 such rows in one section scored 90/A before this
+ * rule existed).
+ *
+ * Pure tree shape — no accessor facts — so it works identically on every
+ * builder: Divi's row > column > module, Gutenberg's columns > column >
+ * paragraph. Bare paragraphs at the root never match (they have no
+ * child-of-child), so ordinary post prose stays silent by construction.
+ * One advisory per run, at the shared parent, not one per row.
+ */
+class Saddle_Lint_Rule_Single_Column_Flow extends Saddle_Lint_Rule {
+
+	/**
+	 * Minimum consecutive single-column wrappers before the page reads as a
+	 * document. Three stacked full-width rows are a common deliberate rhythm
+	 * (intro, body, aside); four or more is a flow, not a composition.
+	 */
+	const MIN_RUN = 4;
+
+	/**
+	 * Rule id.
+	 *
+	 * @return string
+	 */
+	public function id() {
+		return 'single-column-flow';
+	}
+
+	/**
+	 * Flag runs of >= MIN_RUN consecutive single-column single-leaf siblings.
+	 *
+	 * @param array[]              $nodes    Flat node list.
+	 * @param Saddle_Lint_Accessor $accessor Builder accessor.
+	 * @return array[]
+	 */
+	public function check( array $nodes, Saddle_Lint_Accessor $accessor ) {
+		$violations = array();
+
+		$parents = array( null );
+		foreach ( $nodes as $node ) {
+			$parents[] = $node['address'];
+		}
+
+		foreach ( $parents as $parent ) {
+			$children = $this->children( $nodes, $parent );
+			if ( count( $children ) < self::MIN_RUN ) {
+				continue;
+			}
+
+			$run = array();
+			foreach ( $children as $child ) {
+				if ( $this->is_single_column_stack( $nodes, $child ) ) {
+					$run[] = $child;
+					continue;
+				}
+				$violations = array_merge( $violations, $this->flush( $run, $parent ) );
+				$run        = array();
+			}
+			$violations = array_merge( $violations, $this->flush( $run, $parent ) );
+		}
+
+		return $violations;
+	}
+
+	/**
+	 * Whether a node is a single-column stack: exactly one child, which has
+	 * exactly one child, which is a leaf (row > column > module).
+	 *
+	 * @param array[] $nodes Flat node list.
+	 * @param array   $node  Candidate wrapper node.
+	 * @return bool
+	 */
+	private function is_single_column_stack( array $nodes, array $node ) {
+		$columns = $this->children( $nodes, $node['address'] );
+		if ( 1 !== count( $columns ) ) {
+			return false;
+		}
+		$modules = $this->children( $nodes, $columns[0]['address'] );
+		if ( 1 !== count( $modules ) ) {
+			return false;
+		}
+		return array() === $this->children( $nodes, $modules[0]['address'] );
+	}
+
+	/**
+	 * Turn a completed run into at most one advisory.
+	 *
+	 * @param array[]     $run    Consecutive matching siblings.
+	 * @param string|null $parent Their shared parent address.
+	 * @return array[]
+	 */
+	private function flush( array $run, $parent ) {
+		if ( count( $run ) < self::MIN_RUN ) {
+			return array();
+		}
+		return array(
+			$this->violation(
+				null === $parent ? $run[0]['address'] : $parent,
+				self::SEVERITY_WARN,
+				sprintf(
+					/* translators: %d: number of consecutive single-column wrappers. */
+					__( '%d consecutive single-column rows, each holding one module — this reads as a document, not a designed page.', 'saddle' ),
+					count( $run )
+				),
+				__( 'Recompose instead of stacking: merge running text into one module, group related items into 2-3 column rows (features, cards, lists), or pair text with media in an asymmetric split. Keep single-column only where a full-width moment is deliberate.', 'saddle' )
+			),
+		);
+	}
+}

--- a/includes/verify/class-saddle-verify.php
+++ b/includes/verify/class-saddle-verify.php
@@ -104,6 +104,7 @@ class Saddle_Verify {
 
 		$findings = self::merge( $findings );
 		$score    = self::score( $findings );
+		$grade    = self::grade( $score, $findings );
 
 		$overflow = 0;
 		if ( count( $findings ) > self::FINDINGS_CAP ) {
@@ -113,7 +114,7 @@ class Saddle_Verify {
 
 		return array(
 			'score'    => $score,
-			'grade'    => self::grade( $score ),
+			'grade'    => $grade,
 			'counts'   => self::counts( $findings, $overflow ),
 			'findings' => $findings,
 			'overflow' => $overflow,
@@ -269,25 +270,55 @@ class Saddle_Verify {
 	}
 
 	/**
-	 * Letter grade for a score.
+	 * Letter grade for a score, demoted by categorical failures.
 	 *
-	 * @param int $score The score.
+	 * The arithmetic alone let a page with one echo finding score 90/A —
+	 * but "your styling never took effect" is categorically not an A, no
+	 * matter how small the penalty. Any structural finding caps the grade
+	 * at C; any echo finding caps it at B. The numeric score is untouched
+	 * (it stays deterministic arithmetic); only the letter is honest about
+	 * category.
+	 *
+	 * @param int     $score    The score.
+	 * @param array[] $findings Deduped findings (pre-cap).
 	 * @return string
 	 */
-	private static function grade( $score ) {
+	private static function grade( $score, array $findings = array() ) {
 		if ( $score >= 90 ) {
-			return 'A';
+			$letter = 'A';
+		} elseif ( $score >= 75 ) {
+			$letter = 'B';
+		} elseif ( $score >= 60 ) {
+			$letter = 'C';
+		} elseif ( $score >= 40 ) {
+			$letter = 'D';
+		} else {
+			$letter = 'F';
 		}
-		if ( $score >= 75 ) {
-			return 'B';
+
+		foreach ( $findings as $finding ) {
+			if ( 'structural' === $finding['source'] ) {
+				return self::worst( $letter, 'C' );
+			}
 		}
-		if ( $score >= 60 ) {
-			return 'C';
+		foreach ( $findings as $finding ) {
+			if ( 'echo' === $finding['source'] ) {
+				return self::worst( $letter, 'B' );
+			}
 		}
-		if ( $score >= 40 ) {
-			return 'D';
-		}
-		return 'F';
+		return $letter;
+	}
+
+	/**
+	 * The worse of two letter grades.
+	 *
+	 * @param string $a One grade.
+	 * @param string $b Another grade.
+	 * @return string
+	 */
+	private static function worst( $a, $b ) {
+		$order = array( 'A', 'B', 'C', 'D', 'F' );
+		return $order[ max( (int) array_search( $a, $order, true ), (int) array_search( $b, $order, true ) ) ];
 	}
 
 	/**

--- a/saddle.php
+++ b/saddle.php
@@ -49,6 +49,7 @@ require_once SADDLE_DIR . 'includes/lint/rules/class-rule-double-background.php'
 require_once SADDLE_DIR . 'includes/lint/rules/class-rule-mixed-accents.php';
 require_once SADDLE_DIR . 'includes/lint/rules/class-rule-unaligned-buttons.php';
 require_once SADDLE_DIR . 'includes/lint/rules/class-rule-section-padding.php';
+require_once SADDLE_DIR . 'includes/lint/rules/class-rule-single-column-flow.php';
 require_once SADDLE_DIR . 'includes/lint/rules/class-rule-featured-plan.php';
 require_once SADDLE_DIR . 'includes/lint/rules/class-rule-text-contrast.php';
 require_once SADDLE_DIR . 'includes/lint/rules/class-rule-missing-alt.php';

--- a/tests/context-test.php
+++ b/tests/context-test.php
@@ -78,6 +78,27 @@ class Saddle_Context_Test extends WP_UnitTestCase {
 		$this->assertStringContainsString( 'BREAK its layout', $ctx );
 	}
 
+	public function test_native_builder_gets_in_scope_note_instead_of_hands_off_warning() {
+		if ( ! defined( 'ELEMENTOR_VERSION' ) ) {
+			define( 'ELEMENTOR_VERSION', '3.0.0-test' );
+		}
+
+		add_filter(
+			'saddle_native_builders',
+			static function ( $native ) {
+				$native[] = 'Elementor';
+				return $native;
+			}
+		);
+
+		$ctx = Saddle_Context::system_context();
+		remove_all_filters( 'saddle_native_builders' );
+
+		$this->assertStringContainsString( 'dedicated saddle tools', $ctx, 'A native builder must be declared in scope.' );
+		$this->assertStringNotContainsString( 'Prefer leaving builder-built pages alone', $ctx, 'The hands-off warning must not undercut an installed builder addon.' );
+		$this->assertStringContainsString( 'never write a builder page', $ctx, 'The raw-content prohibition must survive.' );
+	}
+
 	public function test_system_context_filter_lets_addons_append_guidance() {
 		add_filter(
 			'saddle_system_context',

--- a/tests/lint-test.php
+++ b/tests/lint-test.php
@@ -203,6 +203,70 @@ class Saddle_Lint_Test extends WP_UnitTestCase {
 		$this->assertSame( array(), $this->by_rule( $scattered, 'section-padding' ) );
 	}
 
+	/* -------- single-column-flow -------- */
+
+	private function single_column_wrapper( $text ) {
+		return '<!-- wp:columns --><div class="wp-block-columns">'
+			. '<!-- wp:column --><div class="wp-block-column">'
+			. '<!-- wp:paragraph --><p>' . $text . '</p><!-- /wp:paragraph -->'
+			. '</div><!-- /wp:column -->'
+			. '</div><!-- /wp:columns -->';
+	}
+
+	public function test_single_column_flow_fires_once_per_run_of_four() {
+		$violations = $this->by_rule(
+			$this->lint(
+				$this->single_column_wrapper( 'One' )
+				. $this->single_column_wrapper( 'Two' )
+				. $this->single_column_wrapper( 'Three' )
+				. $this->single_column_wrapper( 'Four' )
+			),
+			'single-column-flow'
+		);
+
+		$this->assertCount( 1, $violations, 'One advisory per run, not one per row.' );
+		$this->assertSame( '0', $violations[0]['address'] );
+		$this->assertSame( 'warn', $violations[0]['severity'] );
+		$this->assertStringContainsString( '4 consecutive', $violations[0]['message'] );
+		$this->assertNotSame( '', $violations[0]['fix_hint'] );
+	}
+
+	public function test_single_column_flow_silent_below_threshold_and_on_real_composition() {
+		// Three stacked wrappers: a deliberate rhythm, not a document.
+		$three = $this->lint(
+			$this->single_column_wrapper( 'One' )
+			. $this->single_column_wrapper( 'Two' )
+			. $this->single_column_wrapper( 'Three' )
+		);
+		$this->assertSame( array(), $this->by_rule( $three, 'single-column-flow' ) );
+
+		// A column holding two modules breaks the run (that is composition).
+		$hero = '<!-- wp:columns --><div class="wp-block-columns">'
+			. '<!-- wp:column --><div class="wp-block-column">'
+			. '<!-- wp:heading --><h2 class="wp-block-heading">Hi</h2><!-- /wp:heading -->'
+			. '<!-- wp:paragraph --><p>Sub</p><!-- /wp:paragraph -->'
+			. '</div><!-- /wp:column -->'
+			. '</div><!-- /wp:columns -->';
+		$mixed = $this->lint(
+			$this->single_column_wrapper( 'One' )
+			. $this->single_column_wrapper( 'Two' )
+			. $hero
+			. $this->single_column_wrapper( 'Three' )
+			. $this->single_column_wrapper( 'Four' )
+		);
+		$this->assertSame( array(), $this->by_rule( $mixed, 'single-column-flow' ) );
+
+		// Bare prose at the root never matches — ordinary posts stay silent.
+		$prose = $this->lint(
+			'<!-- wp:paragraph --><p>A</p><!-- /wp:paragraph -->'
+			. '<!-- wp:paragraph --><p>B</p><!-- /wp:paragraph -->'
+			. '<!-- wp:paragraph --><p>C</p><!-- /wp:paragraph -->'
+			. '<!-- wp:paragraph --><p>D</p><!-- /wp:paragraph -->'
+			. '<!-- wp:paragraph --><p>E</p><!-- /wp:paragraph -->'
+		);
+		$this->assertSame( array(), $this->by_rule( $prose, 'single-column-flow' ) );
+	}
+
 	/* -------- no-featured-plan -------- */
 
 	private function plan_card( $attrs = array() ) {

--- a/tests/skills-test.php
+++ b/tests/skills-test.php
@@ -62,13 +62,39 @@ class Saddle_Skills_Test extends WP_UnitTestCase {
 		$this->assertStringContainsString( 'Always draft first', $updated['body'] );
 	}
 
-	public function test_install_rejects_missing_frontmatter_and_strips_html() {
+	public function test_install_rejects_missing_frontmatter() {
 		$this->assertWPError( Saddle_Skills::install( "just some text\nwith no frontmatter" ) );
 		$this->assertWPError( Saddle_Skills::install( "---\nname: x\n---\nbody without description" ) );
+	}
 
-		$skill = Saddle_Skills::install( "---\nname: html-test\ndescription: d\n---\nBefore <script>alert(1)</script> after" );
+	public function test_skill_body_preserves_placeholders_and_markup_verbatim() {
+		// The regression that motivated sanitize_body(): wp_kses parsed
+		// instructional placeholders (<id>, <module>, <addr>) as HTML tags
+		// and DELETED them, so agents received "post_id=" instead of
+		// "post_id=<id>". A body is Markdown data served over JSON — it must
+		// round-trip byte-identical (modulo trim).
+		$body = "Call divi-set-page post=<id> nodes=[...]\n"
+			. "Then divi-get-style-schema type=<module> and fix by <addr>.\n"
+			. "Envelope: <attr>.innerContent.desktop.value -> \"on\"\n"
+			. "Loop until score > 90 && warnings < 2.\n"
+			. "Inline markup like <script>example()</script> is prose here, not HTML.";
+
+		$skill = Saddle_Skills::install( "---\nname: placeholder-test\ndescription: d\n---\n" . $body );
 		$this->assertNotWPError( $skill );
-		$this->assertStringNotContainsString( '<script>', $skill['body'], 'HTML must not survive into a skill body.' );
+		$this->assertSame( $body, $skill['body'], 'A skill body must survive byte-identical — placeholders are prose, not tags.' );
+
+		$found = Saddle_Skills::find( 'placeholder-test' );
+		$this->assertSame( $body, $found['body'], 'find() must serve the body unmodified.' );
+	}
+
+	public function test_skill_body_still_sheds_invalid_utf8_and_control_chars() {
+		$skill = Saddle_Skills::install(
+			"---\nname: utf8-test\ndescription: d\n---\nclean\ttext\nline two" . "\x00\x07" . chr( 0xC3 )
+		);
+		$this->assertNotWPError( $skill );
+		$this->assertStringNotContainsString( "\x00", $skill['body'], 'NUL bytes must not survive.' );
+		$this->assertStringNotContainsString( "\x07", $skill['body'], 'Control characters must not survive.' );
+		$this->assertStringContainsString( "clean\ttext\nline two", $skill['body'], 'Tabs and newlines are Markdown structure and must survive.' );
 	}
 
 	/* -------- context injection (the keystone) -------- */
@@ -186,13 +212,17 @@ class Saddle_Skills_Test extends WP_UnitTestCase {
 
 		$this->with_builtin(
 			array(
-				'name'        => 'html-builtin',
+				'name'        => 'placeholder-builtin',
 				'description' => 'd',
-				'body'        => 'Before <script>alert(1)</script> after',
+				'body'        => "Read the tree, then divi-edit-module post=<id> address=<addr>.\nA > B still means A beats B.",
 			),
 			function () {
-				$skill = Saddle_Skills::find( 'html-builtin' );
-				$this->assertStringNotContainsString( '<script>', $skill['body'], 'Builtin bodies must be HTML-stripped too.' );
+				$skill = Saddle_Skills::find( 'placeholder-builtin' );
+				$this->assertSame(
+					"Read the tree, then divi-edit-module post=<id> address=<addr>.\nA > B still means A beats B.",
+					$skill['body'],
+					'Builtin bodies must keep angle-bracket placeholders verbatim (the wp_kses mutilation regression).'
+				);
 			}
 		);
 	}

--- a/tests/verify-test.php
+++ b/tests/verify-test.php
@@ -117,6 +117,34 @@ class Saddle_Verify_Test extends WP_UnitTestCase {
 		$this->assertSame( 75, $result['score'] ); // 100 - 25.
 	}
 
+	/* -------- grade honesty -------- */
+
+	public function test_one_echo_finding_caps_the_grade_at_b() {
+		// 100 - 10 = 90 — numerically an A, categorically not: the styling
+		// never rendered. The letter demotes; the arithmetic stays.
+		$result = $this->verify(
+			$this->page( '<!-- wp:paragraph {"style":{"nonsense":{"x":1}}} --><p>Styled into the void.</p><!-- /wp:paragraph -->' )
+		);
+
+		$this->assertSame( 90, $result['score'] );
+		$this->assertSame( 'B', $result['grade'], 'An ignored attribute is categorically not an A page.' );
+	}
+
+	public function test_structural_finding_caps_the_grade_at_c() {
+		$result = $this->verify( $this->page( '<div class="hand-rolled"><p>Not blocks at all.</p></div>' ) );
+
+		$this->assertSame( 75, $result['score'] ); // Numerically a B.
+		$this->assertSame( 'C', $result['grade'], 'A structural break is categorically not a B page.' );
+	}
+
+	public function test_every_report_carries_the_coverage_caveat() {
+		$clean = $this->verify( $this->page( $this->clean_markup() ) );
+		$dirty = $this->verify( $this->page( $this->bad_markup() ) );
+
+		$this->assertStringContainsString( 'get-preview-url', $clean['coverage'], 'A clean report must still say the score is not a visual sign-off.' );
+		$this->assertStringContainsString( 'get-preview-url', $dirty['coverage'] );
+	}
+
 	/* -------- bounded payload -------- */
 
 	public function test_findings_are_capped_with_an_overflow_count() {


### PR DESCRIPTION
Free-side half of the divitorque design-failure fix stack (3 commits, reviewable commit-by-commit; pairs with plugpressco/saddle-pro#… echo/schema/skill PR).

**Why:** a live design session on divitorque.com produced a visually broken page that scored 90/A. Root causes on the free side:

1. **wp_kses mutilated every skill body** — `<id>`/`<module>`/`<addr>` placeholders were parsed as HTML tags and deleted before any agent saw them (`class-saddle-skills.php:204/348`). Bodies are Markdown-as-data, never rendered; now sanitized for UTF-8/control chars only, byte-identical otherwise. Owner skills installed before this fix were damaged at install time and need re-install.
2. **Verify grades were dishonest** — one echo finding = −10 = 90/A. Structural findings now cap the grade at C, echo at B, and every report carries a `coverage` caveat pointing at get-preview-url for real pixels.
3. **No rule saw the document look** — new builder-agnostic `single-column-flow` lint rule: ≥4 consecutive single-column single-module wrappers get one advisory per run.
4. **Context worked against the Pro addon** — new `saddle_native_builders` filter replaces the "prefer leaving builder pages alone" warning with an in-scope note for builders an addon registers; `design_numbers()` gains the center-a-width-capped-column clause (the most common live miss).

Suite: 443 green (+6 new). Also adds a `saddle_flush_cache` action to `saddle/flush-cache` so addons can invalidate derived caches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MdDtwAWL2u1oDKq5tNANT6