### PR TITLE
fix(guardrails): hold a wrapped destructive confirm to the args it previewed (#89)

### DIFF
--- a/includes/class-saddle-capabilities.php
+++ b/includes/class-saddle-capabilities.php
@@ -72,6 +72,27 @@ class Saddle_Capabilities {
 	);
 
 	/**
+	 * Ability short name => the WordPress capability its permission callback
+	 * requires. Populated by {@see self::permission()} as abilities register.
+	 *
+	 * @var array<string,string>
+	 */
+	private static $caps = array();
+
+	/**
+	 * The WordPress capability an ability requires, or '' when it is unknown
+	 * (nothing registered under that short name yet) or the ability asks only
+	 * for an authenticated user.
+	 *
+	 * @param string $short_name Ability id without the 'saddle/' prefix.
+	 * @return string
+	 */
+	public static function required_cap( $short_name ) {
+		$key = sanitize_key( (string) $short_name );
+		return isset( self::$caps[ $key ] ) ? self::$caps[ $key ] : '';
+	}
+
+	/**
 	 * Ordered list of valid tier names.
 	 *
 	 * @return string[]
@@ -209,6 +230,15 @@ class Saddle_Capabilities {
 	 * @return callable
 	 */
 	public static function permission( $level, $cap = 'read', $short_name = null ) {
+		// Remember which capability this tool asks for. Every ability in every
+		// plugin — free, Pro, and the integration wrappers — builds its callback
+		// here, so this one line is the whole registry, and it costs nothing at
+		// call time. denial_reason() needs it to tell an agent that the account
+		// is short a capability rather than blaming one of the owner's switches.
+		if ( $short_name ) {
+			self::$caps[ sanitize_key( $short_name ) ] = (string) $cap;
+		}
+
 		return function () use ( $level, $cap, $short_name ) {
 			$logged_in = is_user_logged_in();
 
@@ -296,6 +326,24 @@ class Saddle_Capabilities {
 		if ( $ability ) {
 			$meta     = $ability->get_meta();
 			$required = isset( $meta['saddle']['tier'] ) ? (string) $meta['saddle']['tier'] : '';
+
+			// The WordPress account behind the credential is short of a
+			// capability this tool needs. Nothing in the Saddle dashboard fixes
+			// that — the answer is a different account — so it must not be
+			// reported as one of the owner's switches. permission() checks the
+			// capability before the tier, so this branch comes first too.
+			$cap = self::required_cap( $short );
+			if ( '' !== $cap && ! current_user_can( $cap ) ) {
+				return array(
+					'code'    => 'saddle_capability_denied',
+					'message' => sprintf(
+						/* translators: 1: WordPress capability name, 2: tool name. */
+						__( 'The WordPress account this app is connected as cannot "%1$s", which "%2$s" requires. This is the account\'s role, not a Saddle setting — no access level or toggle will change it. Do not retry; tell the user to reconnect Saddle as an account with that permission.', 'saddle' ),
+						$cap,
+						$short
+					),
+				);
+			}
 			if ( '' !== $required && ! self::tier_allows( $required ) ) {
 				// The site allows this, but the credential in hand doesn't — the
 				// app was granted a narrower scope when it was authorized. That

--- a/includes/class-saddle-integrations.php
+++ b/includes/class-saddle-integrations.php
@@ -156,6 +156,44 @@ class Saddle_Integrations {
 	}
 
 	/**
+	 * Input keys that name the item a partner tool acts on, best first.
+	 *
+	 * Only used to make the log line and the token's target readable — the
+	 * `bind` hash is what actually holds a confirm to its preview, so a key
+	 * missing from this list costs legibility, never safety.
+	 *
+	 * @return string[]
+	 */
+	private static function target_keys() {
+		/**
+		 * Filter the input keys treated as a partner tool's target item.
+		 *
+		 * @param string[] $keys Candidate keys, best first.
+		 */
+		return (array) apply_filters(
+			'saddle_integration_target_keys',
+			array( 'id', 'post_id', 'page_id', 'doc_id', 'attachment_id', 'media_id', 'campaign_id', 'term_id', 'user_id', 'redirect_id' )
+		);
+	}
+
+	/**
+	 * Sort an argument array by key, recursively, so two calls carrying the
+	 * same arguments hash the same however the client ordered its JSON.
+	 *
+	 * @param array $args Arguments.
+	 * @return array Key-sorted copy.
+	 */
+	private static function canonical( array $args ) {
+		ksort( $args );
+		foreach ( $args as $key => $value ) {
+			if ( is_array( $value ) ) {
+				$args[ $key ] = self::canonical( $value );
+			}
+		}
+		return $args;
+	}
+
+	/**
 	 * Build the wrapper's execute callback: delegate to the source ability
 	 * (whose own permission_callback core re-checks inside execute()), gate
 	 * destructive calls, and log every mutation.
@@ -190,23 +228,31 @@ class Saddle_Integrations {
 				return $source->execute( array_diff_key( $input, array( 'confirm_token' => true ) ) );
 			};
 
+			// Never the handshake field: the preview call carries no
+			// confirm_token and the confirm call does, so folding it in would
+			// make the two calls differ and nothing could ever be confirmed.
+			$bindable = array_diff_key( $input, array( 'confirm_token' => true ) );
+
 			// A stable-ish target so a preview token can't be replayed
 			// against a different item.
 			$target = '';
-			foreach ( array( 'id', 'post_id', 'attachment_id' ) as $key ) {
-				if ( isset( $input[ $key ] ) && is_scalar( $input[ $key ] ) ) {
-					$target = (string) $input[ $key ];
+			foreach ( self::target_keys() as $key ) {
+				if ( isset( $bindable[ $key ] ) && is_scalar( $bindable[ $key ] ) ) {
+					$target = (string) $bindable[ $key ];
 					break;
 				}
 			}
-			if ( '' === $target && $input ) {
-				// Hash the arguments, but never the handshake field: the preview
-				// call carries no confirm_token and the confirm call does, so
-				// hashing it in would make the target differ between the two and
-				// no destructive keyless tool could ever be confirmed.
-				$bindable = array_diff_key( $input, array( 'confirm_token' => true ) );
-				$target   = $bindable ? substr( md5( wp_json_encode( $bindable ) ), 0, 12 ) : '';
+			if ( '' === $target && $bindable ) {
+				$target = substr( md5( wp_json_encode( $bindable ) ), 0, 12 );
 			}
+
+			// The target names the item; `bind` covers EVERYTHING ELSE the call
+			// carries. Without it only the id was held to the preview, so a
+			// confirm on the same item could arrive with a different payload
+			// and the gate would run it — the user approved one change and got
+			// another (issue #89). Kept out of $target so the log line stays a
+			// readable "#12" rather than a hash.
+			$bind = $bindable ? hash( 'sha256', (string) wp_json_encode( self::canonical( $bindable ) ) ) : '';
 
 			if ( $destructive ) {
 				// The gate logs the confirmed execution itself.
@@ -214,6 +260,7 @@ class Saddle_Integrations {
 					array(
 						'action'  => $short,
 						'target'  => $target,
+						'bind'    => $bind,
 						'summary' => sprintf(
 							/* translators: 1: tool label, 2: target, 3: plugin name. */
 							__( 'Run "%1$s" on %2$s via the %3$s integration. This is flagged destructive by %3$s.', 'saddle' ),

--- a/tests/capabilities-test.php
+++ b/tests/capabilities-test.php
@@ -259,6 +259,46 @@ class Saddle_Capabilities_Test extends WP_UnitTestCase {
 		$this->assertFalse( Saddle_Capabilities::domain_matches_recorded() );
 	}
 
+	/* -------- denial_reason: an agent must be told the right fix -------- */
+
+	public function test_a_capability_denial_blames_the_account_not_a_saddle_switch() {
+		// A subscriber at the admin tier: nothing the owner controls is in the
+		// way, so before #89 this fell through to the generic "none of Saddle's
+		// gates blocked this" paragraph — which lists three fixes, none of them
+		// the real one.
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'subscriber' ) ) );
+		Saddle_Capabilities::set_tier( 'admin' );
+
+		$reason = Saddle_Capabilities::denial_reason( 'saddle/create-post' );
+
+		$this->assertIsArray( $reason, 'A capability denial must be explained, not left to the generic fallback.' );
+		$this->assertSame( 'saddle_capability_denied', $reason['code'] );
+		$this->assertStringContainsString( 'edit_posts', $reason['message'] );
+	}
+
+	public function test_the_owners_switches_still_outrank_a_capability_denial() {
+		// Same under-privileged account, but the tool is also switched off.
+		// permission() checks the toggle first, so the reason must match what
+		// actually refused the call.
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'subscriber' ) ) );
+		Saddle_Capabilities::set_tier( 'admin' );
+		Saddle_Capabilities::set_disabled_abilities( array( 'create-post' ) );
+
+		$reason = Saddle_Capabilities::denial_reason( 'saddle/create-post' );
+
+		$this->assertSame( 'saddle_tool_disabled', $reason['code'] );
+	}
+
+	public function test_an_account_that_holds_the_capability_gets_no_capability_reason() {
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'administrator' ) ) );
+		Saddle_Capabilities::set_tier( 'admin' );
+
+		$this->assertNull(
+			Saddle_Capabilities::denial_reason( 'saddle/create-post' ),
+			'Nothing of Saddle’s blocked this call, so nothing should be claimed.'
+		);
+	}
+
 	public function test_re_saving_the_tier_clears_a_stale_domain_warning() {
 		Saddle_Capabilities::set_tier( 'write' );
 		update_option( Saddle_Capabilities::TIER_DOMAIN_OPTION, 'old-domain.example.test' );

--- a/tests/integrations-test.php
+++ b/tests/integrations-test.php
@@ -84,6 +84,29 @@ class Saddle_Integrations_Test extends WP_UnitTestCase {
 			)
 		);
 		wp_register_ability(
+			'waggle/rewrite-meta',
+			array(
+				'label'               => 'Rewrite SEO meta',
+				'description'         => 'Overwrites a post\'s SEO meta.',
+				'category'            => 'saddle',
+				'input_schema'        => array(
+					'type'       => 'object',
+					'properties' => array(
+						'post_id'     => array( 'type' => 'integer' ),
+						'description' => array( 'type' => 'string' ),
+					),
+				),
+				'execute_callback'    => static function ( $input ) {
+					return array(
+						'post_id'     => (int) $input['post_id'],
+						'description' => (string) $input['description'],
+					);
+				},
+				'permission_callback' => '__return_true',
+				'meta'                => array( 'annotations' => array( 'readonly' => false, 'destructive' => true ) ),
+			)
+		);
+		wp_register_ability(
 			'waggle/reset-settings',
 			array(
 				'label'               => 'Reset settings',
@@ -113,9 +136,11 @@ class Saddle_Integrations_Test extends WP_UnitTestCase {
 					'waggle/get-aeo-score',
 					'waggle/update-seo-meta',
 					'waggle/reset-settings',
+					'waggle/rewrite-meta',
 					'saddle/waggle-get-aeo-score',
 					'saddle/waggle-update-seo-meta',
 					'saddle/waggle-reset-settings',
+					'saddle/waggle-rewrite-meta',
 					'zzz/get-stuff',
 					'saddle/zzz-get-stuff',
 				);
@@ -211,6 +236,52 @@ class Saddle_Integrations_Test extends WP_UnitTestCase {
 		$this->assertWPError( $stolen );
 	}
 
+	public function test_destructive_wrapper_confirm_cannot_change_the_arguments_it_previewed() {
+		// The regression this pins: `$target` is only the id, so on a tool that
+		// takes an id PLUS a payload every other argument was unbound — the
+		// preview showed one thing and the confirm ran another. See issue #89.
+		$ability = wp_get_ability( 'saddle/waggle-rewrite-meta' );
+
+		$preview = $ability->execute(
+			array(
+				'post_id'     => 12,
+				'description' => 'the description the user approved',
+			)
+		);
+		$this->assertNotWPError( $preview );
+		$this->assertArrayHasKey( 'confirm_token', $preview );
+
+		$swapped = $ability->execute(
+			array(
+				'post_id'       => 12,
+				'description'   => 'something else entirely',
+				'confirm_token' => $preview['confirm_token'],
+			)
+		);
+
+		$this->assertWPError(
+			$swapped,
+			'A confirm that changes an argument the preview showed must be refused, not executed.'
+		);
+		$this->assertSame( 'saddle_token_bind_mismatch', $swapped->get_error_code() );
+	}
+
+	public function test_destructive_wrapper_confirms_with_the_same_arguments() {
+		// The other half of the bind: unchanged arguments must still confirm,
+		// or the gate would be unusable on every id-bearing partner tool.
+		$ability = wp_get_ability( 'saddle/waggle-rewrite-meta' );
+
+		$args    = array(
+			'post_id'     => 12,
+			'description' => 'the description the user approved',
+		);
+		$preview = $ability->execute( $args );
+		$done    = $ability->execute( array_merge( $args, array( 'confirm_token' => $preview['confirm_token'] ) ) );
+
+		$this->assertNotWPError( $done );
+		$this->assertSame( 'the description the user approved', $done['description'] );
+	}
+
 	public function test_pause_stops_integration_tools_too() {
 		Saddle_Capabilities::set_paused( true );
 
@@ -268,7 +339,7 @@ class Saddle_Integrations_Test extends WP_UnitTestCase {
 		// Nothing active → context passes through untouched.
 		$this->within_abilities_init(
 			static function () {
-				foreach ( array( 'saddle/waggle-get-aeo-score', 'saddle/waggle-update-seo-meta', 'saddle/waggle-reset-settings' ) as $name ) {
+				foreach ( array( 'saddle/waggle-get-aeo-score', 'saddle/waggle-update-seo-meta', 'saddle/waggle-reset-settings', 'saddle/waggle-rewrite-meta' ) as $name ) {
 					wp_unregister_ability( $name );
 				}
 			}


### PR DESCRIPTION
Closes #89
Refs #63

## What

Two guardrail fixes, both in the "an agent is told the wrong thing" family.

A wrapped destructive tool can no longer be confirmed with different arguments than it previewed. And a capability denial now says so, instead of being reported as one of the site owner's switches.

## Why

**The bind.** `Saddle_Approval::gate()` takes a `bind` parameter precisely so that confirmation-relevant arguments are part of the token's identity — it is what stops a "move to trash" preview being confirmed into a permanent delete. `Saddle_Integrations::executor()` never passed it. The only thing holding a confirm to its preview was `target`, the first of `id` / `post_id` / `attachment_id` found in the input, and the `$delegate` closure captured the **confirm** call's `$input`.

So on any partner tool that takes an id plus a payload — the common shape — the payload was unbound:

1. preview with `{post_id: 12, description: "the one the user approved"}` → preview + token, nothing mutated
2. confirm with `{post_id: 12, description: "something else", confirm_token: …}` → the second one executes

The user approves one change and gets another. That is the two-step confirm doing the opposite of its job, and "no destructive action without a two-step confirm" is the third non-negotiable.

It was invisible in the suite because `tests/integrations-test.php`'s synthetic destructive tool takes a single argument that *is* the target — the one shape where the existing target hash incidentally binds everything.

**The denial.** `denial_reason()` covered paused / not-authenticated / tool-disabled / tier and then returned `null`. A capability denial — already recorded under that exact name by `log_denial()` — reached the agent as the generic "None of Saddle's site-wide gates blocked this…" paragraph, which names three fixes and not the real one. The fix is a different WordPress account; no access level or toggle touches it.

## How

- `bind` is a sha256 of the full argument set minus `confirm_token`, key-sorted recursively so a client that reorders its JSON doesn't break a legitimate confirm. `confirm_token` is excluded for the reason the original comment gives: the preview call doesn't carry one and the confirm call does.
- `target` stays the bare id so the activity-log line remains a readable `#12` rather than a hash. Target keys widened past the original three and put behind `saddle_integration_target_keys` — with the bind in place, a key missing from that list costs legibility, never safety.
- `Saddle_Capabilities::permission()` records the capability each ability asks for as it registers. One line, one site: free, Pro and the integration wrappers all build their callback there, so no registration site changes. `denial_reason()` checks it in the same order `permission()` does, so the owner's switches still outrank it.

## Testing

- [x] `composer test` — 518 tests, 1828 assertions, green (1 pre-existing skip)
- [x] `composer lint` — 0 errors; the 3 warnings are pre-existing and in files this PR doesn't touch
- [x] The bind regression was pinned as a **failing** test first, and it named the symptom: `test_destructive_wrapper_confirm_cannot_change_the_arguments_it_previewed`
- [x] Its other half is pinned too — unchanged arguments must still confirm, or the gate would be unusable on every id-bearing partner tool
- [x] Three `denial_reason()` cases: the capability denial is explained, a disabled tool still outranks it, and a properly-privileged account gets no claim at all
- [x] No notices or warnings with `WP_DEBUG` on

No CI in this repo, so "green" here means the commands above were run locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GkZr73cqaSesHRDG89Yy8S
