### PR TITLE
fix(mcp): answer the handshake the way strict clients require (#97)

### DIFF
--- a/includes/class-saddle-mcp.php
+++ b/includes/class-saddle-mcp.php
@@ -275,10 +275,68 @@ class Saddle_MCP {
 			self::REST_NAMESPACE,
 			self::ROUTE,
 			array(
-				'methods'             => 'POST',
-				'callback'            => array( __CLASS__, 'handle' ),
-				'permission_callback' => array( __CLASS__, 'authenticated' ),
+				array(
+					'methods'             => 'POST',
+					'callback'            => array( __CLASS__, 'handle' ),
+					'permission_callback' => array( __CLASS__, 'authenticated' ),
+				),
+				// GET and DELETE exist only to be refused correctly.
+				//
+				// "The server MUST provide a single HTTP endpoint path … that
+				// supports both POST and GET methods", and for GET: "The server
+				// MUST either return Content-Type: text/event-stream … or else
+				// return HTTP 405 Method Not Allowed."
+				//
+				// Leaving them unregistered looks like it produces that 405 —
+				// WP_REST_Server::dispatch() returns one, which is what a unit
+				// test sees. Over real HTTP it does not: the request never
+				// matches a route and the client gets 404 rest_no_route. A
+				// client probing for a stream reads 404 as a broken endpoint,
+				// so the only way to answer the spec is to own both methods.
+				array(
+					'methods'             => array( 'GET', 'DELETE' ),
+					'callback'            => array( __CLASS__, 'refuse_method' ),
+					'permission_callback' => array( __CLASS__, 'authenticated' ),
+				),
 			)
+		);
+
+		add_filter( 'rest_pre_serve_request', array( __CLASS__, 'serve_empty_acknowledgement' ), 10, 3 );
+	}
+
+	/**
+	 * Answer GET and DELETE with the 405 the spec asks for.
+	 *
+	 * GET: Saddle has no SSE stream to offer, and 405 is the spec's own
+	 * sanctioned way of saying so.
+	 *
+	 * DELETE: "Clients … SHOULD send an HTTP DELETE … to explicitly terminate
+	 * the session. The server MAY respond to this request with HTTP 405 Method
+	 * Not Allowed." This transport is stateless and issues no session id, so
+	 * there is nothing to terminate.
+	 *
+	 * The permission callback still runs first, so an unauthenticated probe
+	 * gets Saddle's legible 401 rather than confirmation that the endpoint is
+	 * here.
+	 *
+	 * @param WP_REST_Request $request The request.
+	 * @return WP_REST_Response
+	 */
+	public static function refuse_method( WP_REST_Request $request ) {
+		// No Allow header set here on purpose. Core's rest_send_allow_header()
+		// runs on rest_post_dispatch and rewrites it from the route's declared
+		// methods, so anything set here is overwritten before the client sees
+		// it — and a test asserting our value would pass while the wire said
+		// something else. That is the same false negative that hid the 404.
+		return new WP_REST_Response(
+			self::error_envelope(
+				null,
+				-32600,
+				'GET' === $request->get_method()
+					? __( 'This MCP endpoint does not offer an event stream. Send JSON-RPC over POST instead.', 'saddle' )
+					: __( 'This MCP endpoint is stateless and issues no session to terminate.', 'saddle' )
+			),
+			405
 		);
 	}
 
@@ -370,10 +428,18 @@ class Saddle_MCP {
 		$ob_level = ob_get_level();
 		ob_start();
 		try {
+			$version = self::protocol_version_error( $request );
+			if ( $version instanceof WP_REST_Response ) {
+				return $version;
+			}
+
 			$body = $request->get_json_params();
 
 			if ( ! is_array( $body ) || array() === $body ) {
-				return new WP_REST_Response( self::error_envelope( null, -32700, __( 'Parse error: request body is not valid JSON-RPC.', 'saddle' ) ), 200 );
+				// 400, not 200: the spec asks for an HTTP error status here,
+				// and a parse failure recorded as a success is a trace row that
+				// reads like everything worked.
+				return self::respond( self::error_envelope( null, -32700, __( 'Parse error: request body is not valid JSON-RPC.', 'saddle' ) ), 400, $request );
 			}
 
 			// A JSON array (sequential integer keys) is a batch of requests.
@@ -387,12 +453,16 @@ class Saddle_MCP {
 						$responses[] = $result;
 					}
 				}
-				// All-notification batches yield no responses; reply with 204-equivalent empty body.
-				return new WP_REST_Response( empty( $responses ) ? null : $responses, 200 );
+				return empty( $responses )
+					? self::acknowledge( $request )
+					: self::respond( $responses, 200, $request );
 			}
 
 			$response = self::dispatch( $body );
-			return new WP_REST_Response( $response, 200 );
+
+			return null === $response
+				? self::acknowledge( $request )
+				: self::respond( $response, 200, $request );
 		} finally {
 			// Handlers may open/close buffers of their own — unwind exactly
 			// back to where this method started, never past it.
@@ -400,6 +470,141 @@ class Saddle_MCP {
 				ob_end_clean();
 			}
 		}
+	}
+
+	/**
+	 * Acknowledge a notification: 202 Accepted, with no body at all.
+	 *
+	 * THE FIX FOR #97, and worth stating plainly because it looks like a
+	 * cosmetic status change. The spec: "If the input is a JSON-RPC response or
+	 * notification … the server MUST return HTTP status code 202 Accepted with
+	 * no body." Saddle answered 200 with the JSON literal `null`.
+	 *
+	 * Every client's handshake is initialize → notifications/initialized →
+	 * tools/list, and the middle step is a notification. A lenient client
+	 * shrugs at the wrong answer and carries on — which is exactly what
+	 * mcp-remote does, and why Claude Desktop worked against a site where
+	 * ChatGPT reported no callable actions. A strict client treats the
+	 * handshake as unfinished and never sends tools/list.
+	 *
+	 * WordPress serializes a null body as the four characters `null`, so "no
+	 * body" takes a deliberate short-circuit: rest_pre_serve_request lets us
+	 * tell WP_REST_Server the response is already served, having printed
+	 * nothing. It removes itself on the way through, so it cannot empty the
+	 * next response in the same process — which the test suite would notice
+	 * long before a site did.
+	 *
+	 * @param WP_REST_Request $request The request being acknowledged.
+	 * @return WP_REST_Response
+	 */
+	private static function acknowledge( WP_REST_Request $request ) {
+		return self::respond( null, 202, $request );
+	}
+
+	/**
+	 * Print nothing for the 202 above, and tell WP_REST_Server it is done.
+	 *
+	 * Registered once, at route registration, rather than added per-request:
+	 * a filter added mid-request only unhooks itself if it actually fires, and
+	 * a response that never reaches the serving stage — short-circuited by
+	 * another plugin, or replaced downstream — would leave it armed to swallow
+	 * the body of whatever came next. Standing and stateless is the version
+	 * that cannot do that.
+	 *
+	 * Narrow on purpose: our own MCP route, and a 202, which nothing else here
+	 * returns.
+	 *
+	 * @param bool             $served   Whether the response has been served.
+	 * @param WP_HTTP_Response $result   The response about to be printed.
+	 * @param WP_REST_Request  $request  The request.
+	 * @return bool
+	 */
+	public static function serve_empty_acknowledgement( $served, $result, $request = null ) {
+		if ( $served || ! $result instanceof WP_HTTP_Response || 202 !== $result->get_status() ) {
+			return $served;
+		}
+
+		if ( ! $request instanceof WP_REST_Request || ! self::owns_route( $request ) ) {
+			return $served;
+		}
+
+		return true;
+	}
+
+	/**
+	 * Whether a request is aimed at Saddle's MCP endpoint.
+	 *
+	 * @param WP_REST_Request $request The request.
+	 * @return bool
+	 */
+	private static function owns_route( WP_REST_Request $request ) {
+		return 0 === strpos( (string) $request->get_route(), '/' . self::REST_NAMESPACE . self::ROUTE );
+	}
+
+	/**
+	 * Build a response, echoing the negotiated protocol version back.
+	 *
+	 * @param mixed                $data    Response payload (null for a 202).
+	 * @param int                  $status  HTTP status.
+	 * @param WP_REST_Request|null $request Originating request.
+	 * @return WP_REST_Response
+	 */
+	private static function respond( $data, $status, $request = null ) {
+		$response = new WP_REST_Response( $data, $status );
+
+		// The spec has the client sending MCP-Protocol-Version on every request
+		// after initialize; echoing it back is what lets a client confirm the
+		// server is speaking the revision it negotiated.
+		$sent = $request instanceof WP_REST_Request ? (string) $request->get_header( 'Mcp-Protocol-Version' ) : '';
+		$response->header( 'MCP-Protocol-Version', '' !== $sent ? $sent : self::PROTOCOL_VERSION );
+
+		return $response;
+	}
+
+	/**
+	 * Refuse a request whose MCP-Protocol-Version header names a revision this
+	 * server does not speak.
+	 *
+	 * "If the server receives a request with an invalid or unsupported
+	 * MCP-Protocol-Version, it MUST respond with 400 Bad Request." Absent the
+	 * header the spec says assume 2025-03-26 and carry on, which matters here:
+	 * every Application Password client in the field omits it, so a missing
+	 * header must never be an error.
+	 *
+	 * 2025-03-26 is accepted even though it is not in SUPPORTED_PROTOCOL_VERSIONS.
+	 * That list drives *negotiation* — what initialize will agree to — and
+	 * widening it there would change what Saddle offers. Here the question is
+	 * only whether a version is recognizable enough not to refuse, and the
+	 * spec names that revision as the one to assume by default; refusing the
+	 * value it tells servers to infer would be perverse.
+	 *
+	 * @param WP_REST_Request $request The request.
+	 * @return WP_REST_Response|null A 400 response, or null when the header is fine.
+	 */
+	private static function protocol_version_error( WP_REST_Request $request ) {
+		$sent = (string) $request->get_header( 'Mcp-Protocol-Version' );
+		if ( '' === $sent ) {
+			return null;
+		}
+
+		$known = array_merge( self::SUPPORTED_PROTOCOL_VERSIONS, array( '2025-03-26' ) );
+		if ( in_array( $sent, $known, true ) ) {
+			return null;
+		}
+
+		return new WP_REST_Response(
+			self::error_envelope(
+				null,
+				-32600,
+				sprintf(
+					/* translators: 1: protocol version the client asked for, 2: comma-separated list of supported versions. */
+					__( 'Unsupported MCP protocol version "%1$s". This server speaks %2$s.', 'saddle' ),
+					$sent,
+					implode( ', ', self::SUPPORTED_PROTOCOL_VERSIONS )
+				)
+			),
+			400
+		);
 	}
 
 	/**
@@ -443,6 +648,22 @@ class Saddle_MCP {
 
 			case 'tools/call':
 				return self::call_tool( $id, $params );
+
+			// Saddle advertises only the `tools` capability, so a conformant
+			// client has no reason to ask for these — but ChatGPT probes all
+			// three during connector setup, and Method-not-found is a poor
+			// answer to hand a client mid-handshake. An empty list costs
+			// nothing and is the truth. The vendored adapter already answers
+			// two of the three this way, so this also stops Saddle's two
+			// transports behaving differently on the same call.
+			case 'resources/list':
+				return self::result_envelope( $id, array( 'resources' => array() ) );
+
+			case 'resources/templates/list':
+				return self::result_envelope( $id, array( 'resourceTemplates' => array() ) );
+
+			case 'prompts/list':
+				return self::result_envelope( $id, array( 'prompts' => array() ) );
 
 			default:
 				// Notifications (e.g. notifications/initialized) carry no id and

--- a/languages/saddle.pot
+++ b/languages/saddle.pot
@@ -9,7 +9,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2026-08-15T14:44:38+00:00\n"
+"POT-Creation-Date: 2026-08-16T03:29:36+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.12.0\n"
 "X-Domain: saddle\n"
@@ -2060,7 +2060,7 @@ msgid "Saddle sign-in keys cannot be used over XML-RPC."
 msgstr ""
 
 #: includes/class-saddle-connection.php:325
-#: includes/class-saddle-mcp.php:341
+#: includes/class-saddle-mcp.php:399
 msgid "Your sign-in key was rejected — it was most likely revoked or removed. Reconnect the app from Saddle to issue a fresh key."
 msgstr ""
 
@@ -2425,47 +2425,61 @@ msgstr ""
 msgid "Tiered, default-safe, approval-gated MCP access to posts, pages, and media."
 msgstr ""
 
-#: includes/class-saddle-mcp.php:330
+#: includes/class-saddle-mcp.php:336
+msgid "This MCP endpoint does not offer an event stream. Send JSON-RPC over POST instead."
+msgstr ""
+
+#: includes/class-saddle-mcp.php:337
+msgid "This MCP endpoint is stateless and issues no session to terminate."
+msgstr ""
+
+#: includes/class-saddle-mcp.php:388
 msgid "The access token was rejected — it has expired, been revoked, or was issued for a different site. Refresh it, or reconnect the app to authorize a new one."
 msgstr ""
 
-#: includes/class-saddle-mcp.php:351
+#: includes/class-saddle-mcp.php:409
 msgid "The request arrived without a sign-in key. If you did connect one, your host may be stripping the Authorization header — open Saddle and run the connection check to confirm and fix it."
 msgstr ""
 
-#: includes/class-saddle-mcp.php:376
+#: includes/class-saddle-mcp.php:442
 msgid "Parse error: request body is not valid JSON-RPC."
 msgstr ""
 
-#: includes/class-saddle-mcp.php:385
+#: includes/class-saddle-mcp.php:451
 msgid "Invalid request."
 msgstr ""
 
+#. translators: 1: protocol version the client asked for, 2: comma-separated list of supported versions.
+#: includes/class-saddle-mcp.php:601
+#, php-format
+msgid "Unsupported MCP protocol version \"%1$s\". This server speaks %2$s."
+msgstr ""
+
 #. translators: %s: JSON-RPC method name.
-#: includes/class-saddle-mcp.php:458
+#: includes/class-saddle-mcp.php:679
 #, php-format
 msgid "Method not found: %s"
 msgstr ""
 
-#: includes/class-saddle-mcp.php:517
+#: includes/class-saddle-mcp.php:738
 msgid "Saddle is paused on this site, so no tools will run. The site owner can resume it in Saddle → Settings. Do not retry until they do."
 msgstr ""
 
-#: includes/class-saddle-mcp.php:529
+#: includes/class-saddle-mcp.php:750
 msgid "Saddle exposes tiered, approval-gated access to this site's posts, pages, and media. Call saddle/get-instructions for the current scope and safety rules before acting."
 msgstr ""
 
-#: includes/class-saddle-mcp.php:697
+#: includes/class-saddle-mcp.php:918
 msgid "Invalid params: a Saddle tool name is required."
 msgstr ""
 
 #. translators: %s: tool name.
-#: includes/class-saddle-mcp.php:707
+#: includes/class-saddle-mcp.php:928
 #, php-format
 msgid "Tool not found: %s"
 msgstr ""
 
-#: includes/class-saddle-mcp.php:737
+#: includes/class-saddle-mcp.php:958
 msgid "None of Saddle’s site-wide gates (pause, access level, per-tool toggles) blocked this — the connected WordPress account likely lacks a capability this tool requires, or the specific item is protected. Do not retry the same call."
 msgstr ""
 

--- a/readme.txt
+++ b/readme.txt
@@ -143,6 +143,7 @@ If you happen to have the separate MCP Adapter plugin active, Saddle notices and
 
 = 1.0.0 =
 * Initial public release.
+* Fixed: some connected apps signed in, reported the connection as healthy, and then said the site had no actions they could use — while the same site worked perfectly from another app. Saddle was answering one step of the connection handshake in a way the stricter apps refuse, so they stopped before ever asking what tools exist. Saddle now answers that step, and the two others it was getting wrong, exactly as the Model Context Protocol requires.
 * Connected apps are now offered only the tools your access level and switches actually allow. A read-only site no longer advertises tools that would be refused on every call — the assistant is told how many are being held back and that only you can unlock them, so it can point you at the setting instead of reporting that your site cannot do it. Raising the access level widens the list again; reconnect the app if it caches what it was told at sign-in.
 * Fixed: a destructive tool from a connected PlugPress plugin could be confirmed with different details than the preview showed. The confirmation now covers everything the preview showed, not just which item it was about.
 * A refused call caused by the WordPress account being short a permission now says so, instead of pointing at Saddle settings that would not have changed anything.

--- a/tests/mcp-transport-test.php
+++ b/tests/mcp-transport-test.php
@@ -10,6 +10,21 @@
 class Saddle_MCP_Transport_Test extends WP_UnitTestCase {
 
 	/**
+	 * Boot the REST server once, before any test's incorrect-usage capture
+	 * starts. Most tests here call Saddle_MCP::handle() directly, but the
+	 * method-negotiation ones have to go through the real server — and booting
+	 * it fires the MCP adapter's default-server registration, which emits a
+	 * `_doing_it_wrong` for an ability it never registered (issue #86).
+	 * Doing it here means that lands outside any test rather than being
+	 * blamed on whichever one dispatches first. Same reason
+	 * nonce-fallback-test.php and oauth-bearer-test.php do it.
+	 */
+	public static function set_up_before_class() {
+		parent::set_up_before_class();
+		rest_get_server();
+	}
+
+	/**
 	 * tools/list is only reachable through the transport gate, which requires
 	 * an authenticated user — and the list is now filtered to what that
 	 * credential can call. So the baseline for these tests is a real
@@ -103,6 +118,261 @@ class Saddle_MCP_Transport_Test extends WP_UnitTestCase {
 		$result = $this->initialize( '2025-11-25' );
 
 		$this->assertStringNotContainsString( 'Plugins active on this site', $result['instructions'] );
+	}
+
+	/* -------- Streamable HTTP conformance (issue #97) -------- */
+
+	/**
+	 * POST a raw JSON-RPC body and return the whole response object, so a test
+	 * can assert on the STATUS as well as the payload. list_tools() below reads
+	 * only the body, which is how a transport could go years answering the
+	 * wrong status codes without a red test.
+	 *
+	 * @param array|string $body    JSON-RPC body (array is encoded).
+	 * @param array        $headers Extra request headers.
+	 * @return WP_REST_Response
+	 */
+	private function post( $body, array $headers = array() ) {
+		$req = new WP_REST_Request( 'POST', '/saddle/v1/mcp' );
+		$req->set_header( 'content-type', 'application/json' );
+		foreach ( $headers as $name => $value ) {
+			$req->set_header( $name, $value );
+		}
+		$req->set_body( is_string( $body ) ? $body : wp_json_encode( $body ) );
+
+		return Saddle_MCP::handle( $req );
+	}
+
+	/**
+	 * THE BUG (issue #97). Every client's handshake is initialize →
+	 * notifications/initialized → tools/list. The middle step is a
+	 * notification, and the spec is unambiguous: "If the input is a JSON-RPC
+	 * response or notification … the server MUST return HTTP status code 202
+	 * Accepted with no body."
+	 *
+	 * Saddle answered 200 with the JSON literal `null`. mcp-remote shrugs and
+	 * carries on — which is why Claude Desktop worked against the very same
+	 * site. A strict client treats the handshake as unfinished and never sends
+	 * tools/list, which reaches the user as "connected, but it exposes no
+	 * callable actions".
+	 */
+	public function test_a_notification_is_accepted_with_202_and_no_body() {
+		$response = $this->post(
+			array(
+				'jsonrpc' => '2.0',
+				'method'  => 'notifications/initialized',
+			)
+		);
+
+		$this->assertSame( 202, $response->get_status(), 'A notification must be acknowledged with 202 Accepted.' );
+		$this->assertNull( $response->get_data(), 'A 202 acknowledgement must carry no body.' );
+	}
+
+	public function test_an_all_notification_batch_is_also_202() {
+		$response = $this->post(
+			array(
+				array( 'jsonrpc' => '2.0', 'method' => 'notifications/initialized' ),
+				array( 'jsonrpc' => '2.0', 'method' => 'notifications/cancelled' ),
+			)
+		);
+
+		$this->assertSame( 202, $response->get_status() );
+		$this->assertNull( $response->get_data() );
+	}
+
+	/**
+	 * The other half of the 202 change: a real request must still come back
+	 * 200 with its envelope. Suppressing the body is scoped to the
+	 * acknowledgement, and a filter that leaked would empty every response.
+	 */
+	public function test_a_real_request_still_returns_200_with_its_envelope() {
+		$response = $this->post( array( 'jsonrpc' => '2.0', 'id' => 1, 'method' => 'ping' ) );
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertSame( '2.0', $response->get_data()['jsonrpc'] );
+	}
+
+	/**
+	 * The status is only half of it: "with no body" is delivered by a
+	 * rest_pre_serve_request short-circuit, which lives in the serving stage
+	 * that handle() never reaches. These drive that filter directly, because
+	 * a 202 whose body still says `null` would look identical in every other
+	 * assertion here.
+	 */
+	public function test_the_acknowledgement_body_is_suppressed_at_the_serving_stage() {
+		$request = new WP_REST_Request( 'POST', '/saddle/v1/mcp' );
+
+		$this->assertTrue(
+			Saddle_MCP::serve_empty_acknowledgement( false, new WP_REST_Response( null, 202 ), $request ),
+			'Reporting the response as already served is what stops WordPress printing "null".'
+		);
+	}
+
+	public function test_the_suppressor_leaves_every_other_response_alone() {
+		$ours = new WP_REST_Request( 'POST', '/saddle/v1/mcp' );
+
+		$this->assertFalse(
+			Saddle_MCP::serve_empty_acknowledgement( false, new WP_REST_Response( array( 'jsonrpc' => '2.0' ), 200 ), $ours ),
+			'A real JSON-RPC response must still be printed.'
+		);
+
+		$this->assertFalse(
+			Saddle_MCP::serve_empty_acknowledgement( false, new WP_REST_Response( array( 'x' => 1 ), 202 ), new WP_REST_Request( 'POST', '/wp/v2/posts' ) ),
+			'A 202 from someone else’s route is none of our business.'
+		);
+
+		$this->assertTrue(
+			Saddle_MCP::serve_empty_acknowledgement( true, new WP_REST_Response( null, 202 ), $ours ),
+			'Already served by someone else stays served.'
+		);
+	}
+
+	/**
+	 * The full handshake, in order. Nothing exercised this sequence end to end
+	 * before, which is exactly how a break in the middle of it shipped.
+	 */
+	public function test_the_whole_handshake_runs_and_ends_with_tools() {
+		$init = $this->post(
+			array(
+				'jsonrpc' => '2.0',
+				'id'      => 1,
+				'method'  => 'initialize',
+				'params'  => array( 'protocolVersion' => '2025-06-18' ),
+			)
+		);
+		$this->assertSame( 200, $init->get_status() );
+		$this->assertSame( '2025-06-18', $init->get_data()['result']['protocolVersion'] );
+
+		$ack = $this->post( array( 'jsonrpc' => '2.0', 'method' => 'notifications/initialized' ) );
+		$this->assertSame( 202, $ack->get_status(), 'The step between "connected" and "has tools".' );
+
+		$list = $this->post( array( 'jsonrpc' => '2.0', 'id' => 2, 'method' => 'tools/list' ) );
+		$this->assertSame( 200, $list->get_status() );
+		$this->assertNotEmpty( $list->get_data()['result']['tools'] );
+	}
+
+	/**
+	 * "The server MUST either return Content-Type: text/event-stream in
+	 * response to this HTTP GET, or else return HTTP 405 Method Not Allowed."
+	 * Saddle has no stream to offer, so 405 it is.
+	 *
+	 * A warning for anyone changing this: leaving GET unregistered LOOKS like
+	 * it satisfies the spec, because WP_REST_Server::dispatch() answers a
+	 * method mismatch with 405 — so a test written against dispatch() passes
+	 * while real clients get 404 rest_no_route. That is exactly the false
+	 * negative this test used to give, and only a curl against a real install
+	 * caught it. Assert on the Allow header too: it is the part that proves
+	 * our own handler produced this rather than core's routing.
+	 */
+	public function test_get_and_delete_are_refused_with_405() {
+		foreach ( array( 'GET', 'DELETE' ) as $method ) {
+			$response = Saddle_MCP::refuse_method( new WP_REST_Request( $method, '/saddle/v1/mcp' ) );
+
+			$this->assertSame( 405, $response->get_status(), "{$method} must be refused with 405, not 404." );
+			$this->assertSame( -32600, $response->get_data()['error']['code'] );
+		}
+	}
+
+	/**
+	 * The handler is only half of it — it has to be ROUTED to, and this suite
+	 * cannot prove that: the dev tree contains the vendored adapter, so
+	 * Saddle::setup_mcp_transport() hands /saddle/v1/mcp to the adapter and
+	 * Saddle_MCP::register_routes() never runs here. Dispatching through
+	 * rest_get_server() in this file reaches the ADAPTER's route, not ours.
+	 *
+	 * That is precisely how the 404 got missed: dispatch() answers a method
+	 * mismatch with 405 regardless, so the old test passed while real clients
+	 * on a .org build got 404. The routing half is verified with curl against
+	 * a Playground install running the built wporg zip — see the PR.
+	 */
+	public function test_this_suite_exercises_the_builtin_handler_not_the_adapter_route() {
+		$this->assertTrue(
+			Saddle::adapter_available(),
+			'If this ever fails, the note above is stale and these tests changed meaning.'
+		);
+	}
+
+	/**
+	 * Registering GET must not turn the endpoint into an unauthenticated probe
+	 * that confirms Saddle is installed here.
+	 */
+	public function test_an_unauthenticated_get_is_still_401() {
+		$current = get_current_user_id();
+		wp_set_current_user( 0 );
+
+		$response = rest_get_server()->dispatch( new WP_REST_Request( 'GET', '/saddle/v1/mcp' ) );
+
+		wp_set_current_user( $current );
+
+		$this->assertSame( 401, $response->get_status(), 'Authentication comes before method negotiation.' );
+	}
+
+	/**
+	 * Saddle advertises only the tools capability, so a conformant client
+	 * should never ask — but Mark's ChatGPT demonstrably probes all three, and
+	 * Method-not-found is a poor answer to give a client mid-handshake. The
+	 * vendored adapter already answers two of these with empty lists, so this
+	 * also closes a difference between Saddle's two transports.
+	 */
+	public function test_resource_and_prompt_probes_get_empty_lists_not_method_not_found() {
+		foreach ( array(
+			'resources/list'           => 'resources',
+			'resources/templates/list' => 'resourceTemplates',
+			'prompts/list'             => 'prompts',
+		) as $method => $key ) {
+			$data = $this->post( array( 'jsonrpc' => '2.0', 'id' => 3, 'method' => $method ) )->get_data();
+
+			$this->assertArrayNotHasKey( 'error', $data, "{$method} must not answer Method not found." );
+			$this->assertSame( array(), $data['result'][ $key ], "{$method} must answer with an empty list." );
+		}
+	}
+
+	/**
+	 * An unknown method that ISN'T one of those probes must still be refused —
+	 * answering everything would be worse than answering nothing.
+	 */
+	public function test_a_genuinely_unknown_method_is_still_refused() {
+		$data = $this->post( array( 'jsonrpc' => '2.0', 'id' => 4, 'method' => 'completion/complete' ) )->get_data();
+
+		$this->assertSame( -32601, $data['error']['code'] );
+	}
+
+	/**
+	 * "If the server receives a request with an invalid or unsupported
+	 * MCP-Protocol-Version, it MUST respond with 400 Bad Request."
+	 */
+	public function test_an_unsupported_protocol_version_header_is_400() {
+		$response = $this->post(
+			array( 'jsonrpc' => '2.0', 'id' => 5, 'method' => 'ping' ),
+			array( 'MCP-Protocol-Version' => '1999-01-01' )
+		);
+
+		$this->assertSame( 400, $response->get_status() );
+	}
+
+	public function test_a_supported_protocol_version_header_passes_and_is_echoed() {
+		$response = $this->post(
+			array( 'jsonrpc' => '2.0', 'id' => 6, 'method' => 'ping' ),
+			array( 'MCP-Protocol-Version' => '2025-06-18' )
+		);
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertSame( '2025-06-18', $response->get_headers()['MCP-Protocol-Version'] );
+	}
+
+	/**
+	 * Absent the header the spec says assume 2025-03-26 — i.e. carry on, never
+	 * refuse. Every Application Password client in the field omits it.
+	 */
+	public function test_a_missing_protocol_version_header_is_fine() {
+		$this->assertSame( 200, $this->post( array( 'jsonrpc' => '2.0', 'id' => 7, 'method' => 'ping' ) )->get_status() );
+	}
+
+	public function test_an_unparseable_body_is_400() {
+		$response = $this->post( 'this is not json' );
+
+		$this->assertSame( 400, $response->get_status() );
+		$this->assertSame( -32700, $response->get_data()['error']['code'] );
 	}
 
 	/**

--- a/tests/oauth-bearer-test.php
+++ b/tests/oauth-bearer-test.php
@@ -238,6 +238,63 @@ class Saddle_OAuth_Bearer_Test extends WP_UnitTestCase {
 		$this->assertTrue( Saddle_Capabilities::tier_allows( 'write' ) );
 	}
 
+	/* ------------------------------------------------------------------
+	 * What a token is OFFERED — the tier filter, over the OAuth path
+	 * --------------------------------------------------------------- */
+
+	/**
+	 * tools/list is filtered to what the credential can call, and the tier it
+	 * reads comes from a different route on this path: tier_ceiling() →
+	 * scope_to_tier() → the saddle_tier_ceiling filter. The clamp tests above
+	 * prove the tier is right; these prove the TOOL LIST that now depends on
+	 * it is right, which is the part a connected app actually sees.
+	 *
+	 * Worth its own cover because an empty list here is indistinguishable, from
+	 * the user's side, from the bug this whole branch is about: an app that
+	 * signs in fine and then reports no callable actions.
+	 *
+	 * @param string $scope Granted scope.
+	 * @return string[] Tool names offered to that token.
+	 */
+	private function tools_offered_to( $scope ) {
+		$this->issue_token( $scope );
+		Saddle_OAuth_Bearer::resolve( false );
+		wp_set_current_user( $this->admin );
+
+		$req = new WP_REST_Request( 'POST', '/saddle/v1/mcp' );
+		$req->set_header( 'content-type', 'application/json' );
+		$req->set_body( wp_json_encode( array( 'jsonrpc' => '2.0', 'id' => 1, 'method' => 'tools/list' ) ) );
+
+		return wp_list_pluck( Saddle_MCP::handle( $req )->get_data()['result']['tools'], 'name' );
+	}
+
+	public function test_a_read_token_is_offered_the_read_tools_and_no_others() {
+		Saddle_Capabilities::set_tier( 'admin' );
+
+		$names = $this->tools_offered_to( 'saddle:read' );
+
+		$this->assertNotEmpty( $names, 'A read token must still be offered the whole read surface.' );
+		$this->assertContains( 'saddle-list-posts', $names );
+		$this->assertNotContains( 'saddle-create-post', $names, 'The scope narrows the list, even on an admin-tier site.' );
+	}
+
+	public function test_a_write_token_is_offered_the_write_tools() {
+		Saddle_Capabilities::set_tier( 'admin' );
+
+		$names = $this->tools_offered_to( 'saddle:write' );
+
+		$this->assertContains( 'saddle-create-post', $names );
+		$this->assertNotContains( 'saddle-list-plugins', $names, 'write is still not admin.' );
+	}
+
+	public function test_an_admin_token_on_an_admin_site_is_offered_everything() {
+		Saddle_Capabilities::set_tier( 'admin' );
+
+		$names = $this->tools_offered_to( 'saddle:admin' );
+
+		$this->assertContains( 'saddle-list-plugins', $names );
+	}
+
 	public function test_the_denial_reason_sends_the_user_to_reconnect_not_to_permissions() {
 		Saddle_Capabilities::set_tier( 'admin' );
 		$this->issue_token( 'saddle:read' );


### PR DESCRIPTION
Closes #97
Refs #80

## What Mark's testing proved

Same endpoint, same site, same credentials, on `staging.kesuk.net`:

- **Claude Desktop via `mcp-remote`** discovered the tools and called them — `saddle-list-pages` returned 90 pages, `saddle-search-content` returned 135 matches for "Microsoft 365".
- **ChatGPT** completed OAuth, was recognised, read resources, then reported the site *"exposes no callable WordPress actions or data access in this session"*.

So abilities, tiers, OAuth and the endpoint were all fine. The handshake was broken, against a client strict enough to care.

## Root cause

Every client performs `initialize` → `notifications/initialized` → `tools/list`. The middle step is a notification, and the [spec](https://modelcontextprotocol.io/specification/2025-06-18/basic/transports) is unambiguous:

> If the input is a JSON-RPC *response* or *notification* … the server **MUST** return HTTP status code 202 Accepted with no body.

Saddle answered **200 with the JSON literal `null`**. A lenient client shrugs and carries on — exactly what `mcp-remote` does, and the whole reason Claude worked. A strict one treats the handshake as unfinished and never asks what tools exist.

Three MUSTs were being missed, all in this transport.

## This is not only Mark's problem

Since `bff1a99` stopped shipping the vendored adapter to WordPress.org, **this transport is the only one a `.org` install will ever have.** `Saddle_MCP_Compat` — which fixed the same *user-visible* symptom for the adapter in #80 — is registered only when the adapter is present, correctly, since it exists to work around the adapter's strictness. Nobody had since checked the transport `.org` users actually get.

## The fixes

- **Notifications → `202`, genuinely empty body.** WordPress serializes a null body as the four characters `null`, so emptiness takes a deliberate `rest_pre_serve_request` short-circuit. Registered **once at route registration**, not per-request: a filter added mid-request only unhooks itself if it fires, and a response that never reaches the serving stage would leave it armed to swallow whatever came next.
- **`GET` → `405`** (was 404), the spec's sanctioned way for a server with no SSE stream to say so; **`DELETE` → `405`** (was 400), since this transport is stateless and issues no session to terminate. Both keep the permission callback, so an anonymous probe still gets 401 rather than confirmation Saddle lives here.
- **Unsupported `MCP-Protocol-Version` → `400`**, negotiated version echoed back. A *missing* header stays fine — the spec says assume `2025-03-26`, and every Application Password client in the field omits it.
- **Unparseable body → `400`** (was 200 — a parse failure was recorded in the traffic trace as a success).
- **`resources/list`, `resources/templates/list`, `prompts/list` → empty lists** rather than `-32601`. Saddle advertises only the `tools` capability so a conformant client would not ask, but ChatGPT demonstrably probes all three, and the vendored adapter already answers two of them this way.

## A warning for whoever touches this next

Leaving `GET` unregistered **looks** conformant, because `WP_REST_Server::dispatch()` answers a method mismatch with 405 — so a test written against `dispatch()` passes while real clients get `404 rest_no_route`. I wrote exactly that test, concluded "already correct, nothing to do", and only caught it by curling a real install.

The suite cannot route to this transport at all: the dev tree carries the vendored adapter, so `Saddle_MCP::register_routes()` never runs and `dispatch()` reaches the *adapter's* route. Hence the handler is unit-tested directly and the routing is verified on the wire. There is a test asserting that assumption still holds, so this note cannot silently go stale.

## Testing

- [x] `composer test` — 560 tests, 1892 assertions, green (1 pre-existing skip)
- [x] `composer lint` — 0 errors
- [x] **On the wire**, against `dist/saddle` built through the **wporg channel** (adapter genuinely absent — confirmed: no `includes/lib`, no updater), served by WP Playground on PHP 8.2 / WP 6.9:

```
initialize                : 200 (5605B)
notifications/initialized : 202 (0B)      <- was 200, body "null"
tools/list                : 200 (58206B), 66 tools
GET                       : 405           <- was 404
DELETE                    : 405           <- was 400
anon GET                  : 401
```

- [x] New: the full `initialize` → `notifications/initialized` → `tools/list` sequence as one test — the thing that broke, which nothing exercised end to end
- [x] New: OAuth-bearer cover for the tier filter merged in `06277d3`, whose tests were Application-Password only. That is the path Mark is on, and its failure mode would look identical to this bug
- [x] No notices or warnings with `WP_DEBUG` on

No CI in this repo, so "green" means the commands above were run locally.

## Worth knowing

`tools/list` is **58KB** at the admin tier. The tier filter narrows that to the read surface on a default install, but it is a real number to keep an eye on.

If ChatGPT still shows nothing after this, the next step is the **Client traffic** panel: a `tools/list` row with status 200 and a non-zero count would mean Saddle is conformant and the tools are being dropped inside ChatGPT — a [documented](https://community.openai.com/t/mcp-connected-but-not-invokable/1384847) class of connector bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GkZr73cqaSesHRDG89Yy8S
