### PR TITLE
chore: build 1.0.0-rc4 for testing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "saddle",
-	"version": "1.0.0-rc3",
+	"version": "1.0.0-rc4",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "saddle",
-			"version": "1.0.0-rc3",
+			"version": "1.0.0-rc4",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@plugpress/ui": "^0.12.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "saddle",
-	"version": "1.0.0-rc3",
+	"version": "1.0.0-rc4",
 	"description": "Self-hosted MCP server for WordPress — admin UI build.",
 	"author": "PlugPress",
 	"license": "GPL-2.0-or-later",

--- a/saddle.php
+++ b/saddle.php
@@ -3,7 +3,7 @@
  * Plugin Name:       Saddle – Control Your Site with AI (MCP Server)
  * Plugin URI:        https://plugpress.co/saddle/
  * Description:       Self-hosted MCP server for WordPress. Tiered, default-safe, approval-gated access to posts, pages, and media for AI agents — with no third-party credential custody.
- * Version:           1.0.0-rc3
+ * Version:           1.0.0-rc4
  * Requires at least: 6.9
  * Requires PHP:      7.4
  * Author:            PlugPress
@@ -18,7 +18,7 @@
 
 defined( 'ABSPATH' ) || exit;
 
-define( 'SADDLE_VERSION', '1.0.0-rc3' );
+define( 'SADDLE_VERSION', '1.0.0-rc4' );
 define( 'SADDLE_FILE', __FILE__ );
 define( 'SADDLE_DIR', plugin_dir_path( __FILE__ ) );
 define( 'SADDLE_URL', plugin_dir_url( __FILE__ ) );


### PR DESCRIPTION
## Why a new number

**18 commits** landed on `main` since the rc3 zip was cut — the MCP handshake fix Mark's report led to, the tier-filtered tool list, the whole July phase stack, the undeclared second endpoint, and the move to `@plugpress/ui` from npm.

Rebuilding under rc3 would be the exact mistake `CLAUDE.md` names: two different zips under one number, after which *"I'm on rc3"* carries no information.

Bumped in the four places that move for a release candidate. `readme.txt`'s **`Stable tag` deliberately stays at 1.0.0** — it never moves for an rc, and `version_compare` sorts `1.0.0-rc4` below `1.0.0`, so every rc install still upgrades cleanly onto the real release.

## The zip

`dist/saddle-1.0.0-rc4.zip` — wporg channel (`npx grunt build`, never `grunt release`). 119 files, 616K.

Verified against the **zip**, not the source tree:

| check | result |
|---|---|
| root folder is exactly `saddle` | ✓ (any other name forces a text-domain mismatch on every string) |
| `class-saddle-updater.php` | absent |
| `includes/lib/` (vendored adapter) | absent |
| tests, dist, scripts, node_modules, vendor | absent |
| dotfiles, Gruntfile, package.json, composer.json, phpunit | absent |
| markdown | none |
| version inside the zip | `1.0.0-rc4` / `SADDLE_VERSION` / Stable tag `1.0.0` |

## "Makes no outbound request" — re-checked, not asserted

- The only scheduled event is `saddle_gc_tokens`, a local DB sweep. No remote call on cron.
- The two self-checks target `rest_url()` and `home_url()` — the site's own address.
- Unsplash only fires with a key the owner entered.
- The `Saddle_Updater` reference in `saddle.php` survives as a `class_exists()` no-op because the class file isn't in this zip. That's the designed mechanism, not a leak.

## Not verified — please run before submitting

**Plugin Check against the built zip.** I could not get it to run headlessly: this release has no `Check_Runner_Factory`, its runners are WP-CLI/AJAX-coupled, and Playground's `wp-cli` step surfaced no output. `composer lint` (WPCS) is clean at 0 errors, but that is **not the same tool** — Plugin Check adds readme parsing, trademark and repo-specific checks that phpcs does not cover.

It needs a pass from the Plugin Check admin UI against this zip. Everything else on the release checklist is green.

## Everything else

- `composer test` — 577 tests, 1944 assertions, green (1 pre-existing skip)
- `composer lint` — 0 errors · `npm run lint:js` — 0 problems
- Committed admin bundle verified in sync with source
- `languages/saddle.pot` in sync (zero msgid delta)
- Six execution functions: zero hits outside the vendored adapter
- No filesystem writes outside the vendored adapter

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GkZr73cqaSesHRDG89Yy8S