### PR TITLE
chore: build 1.0.0-rc5 for testing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "saddle",
-	"version": "1.0.0-rc4",
+	"version": "1.0.0-rc5",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "saddle",
-			"version": "1.0.0-rc4",
+			"version": "1.0.0-rc5",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@plugpress/ui": "^0.12.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "saddle",
-	"version": "1.0.0-rc4",
+	"version": "1.0.0-rc5",
 	"description": "Self-hosted MCP server for WordPress — admin UI build.",
 	"author": "PlugPress",
 	"license": "GPL-2.0-or-later",

--- a/saddle.php
+++ b/saddle.php
@@ -3,7 +3,7 @@
  * Plugin Name:       Saddle – Control Your Site with AI (MCP Server)
  * Plugin URI:        https://plugpress.co/saddle/
  * Description:       Self-hosted MCP server for WordPress. Tiered, default-safe, approval-gated access to posts, pages, and media for AI agents — with no third-party credential custody.
- * Version:           1.0.0-rc4
+ * Version:           1.0.0-rc5
  * Requires at least: 6.9
  * Requires PHP:      7.4
  * Author:            PlugPress
@@ -18,7 +18,7 @@
 
 defined( 'ABSPATH' ) || exit;
 
-define( 'SADDLE_VERSION', '1.0.0-rc4' );
+define( 'SADDLE_VERSION', '1.0.0-rc5' );
 define( 'SADDLE_FILE', __FILE__ );
 define( 'SADDLE_DIR', plugin_dir_path( __FILE__ ) );
 define( 'SADDLE_URL', plugin_dir_url( __FILE__ ) );


### PR DESCRIPTION
Refs #107

## What

Bumps to `1.0.0-rc5` so the build carrying the OAuth scope fix (#108) is distinguishable from `rc4`, which shipped without it.

## Why

`dist/saddle-1.0.0-rc4.zip` already exists and does not contain the fix. Rebuilding under the same number would mean two different zips called rc4, with no way to tell from the admin which one a site is running.

## How

Bumped in four places — plugin header, `SADDLE_VERSION`, `package.json`, `package-lock.json`. **`Stable tag` deliberately stays at `1.0.0`**: it never moves for a release candidate, and `version_compare` sorts `1.0.0-rc5` below `1.0.0`, so every rc install upgrades cleanly onto the real release when it lands.

Built `--channel=selfhosted` for our own sites. Zip verified:

- `Version:` and `SADDLE_VERSION` both `1.0.0-rc5`
- `site_scope()` / `tier_to_scope()` (×4), `set_grant_scope()`, `update_oauth_connection()` (×2) all present
- `class-saddle-updater.php` included — correct for this channel, and the reason this zip must never go to WordPress.org
- zero dev files (`tests/`, `node_modules/`, dot-files, `Gruntfile`, `STATUS.md`, `CLAUDE.md`)
- admin bundle carries the new level picker
- `php scripts/revendor-wp-mcp.php --check` clean

## Testing

- [x] `composer test` — 594 tests green (run on #108 before merge)
- [x] `composer lint` — 0 errors
- [x] Zip contents verified as above
- [ ] Live install on the affected site — next step