### PR TITLE
fix: keep the vendored adapter out of the self-hosted channel (#113)

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -124,9 +124,13 @@ module.exports = function ( grunt ) {
 							// installs the official MCP Adapter plugin gets the
 							// adapter path back automatically.
 							//
-							// Keep this exclusion in the WordPress.org build. When
-							// the self-hosted channel lands, re-include it there the
-							// same way that branch re-includes the updater.
+							// Excluded on BOTH channels, not just .org. The earlier
+							// plan was to re-include it for self-hosted; that was
+							// written before Saddle_MCP's own transport was hardened
+							// as the one a .org install will ever have, and shipping
+							// a different transport to testers than to .org users
+							// costs us the field evidence we most need. Tracked as
+							// its own decision in #113.
 							'!includes/lib/**',
 							// The loader that declares the library's own reserved
 							// WP_MCP_* constants. Useless without the library, and
@@ -152,6 +156,7 @@ module.exports = function ( grunt ) {
 							// SessionManager is absent, so it costs a .org build
 							// nothing. Unlike the updater, its absence is not a
 							// guarantee we are making to anyone.
+							//
 							// WP.org listing assets — go to SVN assets/, never in the zip.
 							'!.wordpress.org/**',
 							// Lint config — dev-only.
@@ -274,20 +279,22 @@ module.exports = function ( grunt ) {
 			}
 
 			if ( 'selfhosted' === channel ) {
-				// Put the self-hosted-only files back by appending un-negated
-				// patterns after the exclusions — grunt-contrib-copy applies src
-				// patterns in order, so the later include wins.
+				// Put the updater back by appending an un-negated pattern after
+				// the exclusion — grunt-contrib-copy applies src patterns in
+				// order, so the later include wins.
 				//
-				// The adapter belongs here and did not arrive with the updater:
-				// the exclusion list has said "re-include it there the same way
-				// that branch re-includes the updater" since the channel landed,
-				// and this branch only ever pushed the updater (#111). Every
-				// build shipped so far therefore runs the JSON-RPC transport
-				// unless the site installs the official adapter plugin itself.
+				// The updater is the ONLY difference between the two channels,
+				// and that is the invariant to protect: a self-hosted build is
+				// the .org artifact plus an update check, so a customer testing
+				// a build is testing what .org ships. The exclusion list above
+				// asks for the vendored adapter to be re-added here too — that
+				// predates the JSON-RPC transport being hardened as the one a
+				// .org install will ever have, and re-adding it would make the
+				// tester's transport differ from the shipped one in the exact
+				// subsystem we most need field evidence about. Left as its own
+				// decision (#113), deliberately not bundled into #111.
 				const files = grunt.config.get( 'copy.dist.files' );
 				files[ 0 ].src.push( 'includes/class-saddle-updater.php' );
-				files[ 0 ].src.push( 'includes/lib/**' );
-				files[ 0 ].src.push( 'includes/class-saddle-bundled-adapter.php' );
 				grunt.config.set( 'copy.dist.files', files );
 			}
 

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -291,8 +291,9 @@ module.exports = function ( grunt ) {
 				// predates the JSON-RPC transport being hardened as the one a
 				// .org install will ever have, and re-adding it would make the
 				// tester's transport differ from the shipped one in the exact
-				// subsystem we most need field evidence about. Left as its own
-				// decision (#113), deliberately not bundled into #111.
+				// subsystem we most need field evidence about. #112 acted on
+				// that comment; this reverts that half and leaves it as its own
+				// decision (#113). The shim half of #112 stands.
 				const files = grunt.config.get( 'copy.dist.files' );
 				files[ 0 ].src.push( 'includes/class-saddle-updater.php' );
 				grunt.config.set( 'copy.dist.files', files );

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -128,13 +128,30 @@ module.exports = function ( grunt ) {
 							// the self-hosted channel lands, re-include it there the
 							// same way that branch re-includes the updater.
 							'!includes/lib/**',
-							// The two files that exist only to serve it: the
-							// loader (which declares the library's own reserved
-							// WP_MCP_* constants) and the shim for its session
-							// strictness. Both are guarded with file_exists()/
-							// class_exists() and degrade to no-ops.
+							// The loader that declares the library's own reserved
+							// WP_MCP_* constants. Useless without the library, and
+							// guarded with class_exists() at the call site.
 							'!includes/class-saddle-bundled-adapter.php',
-							'!includes/class-saddle-mcp-compat.php',
+							// class-saddle-mcp-compat.php is deliberately NOT
+							// excluded, on either channel. It used to be, and that
+							// is how the ChatGPT fix in #80/#81 shipped to nobody
+							// for a month (#111).
+							//
+							// The trap: adapter_available() tests for
+							// \WP\MCP\Core\McpAdapter, not for OUR bundled copy. A
+							// site that installs the official MCP Adapter plugin
+							// takes the adapter path on ANY channel, including
+							// .org — and then class_exists( 'Saddle_MCP_Compat' )
+							// is false, the shim never registers, and the owner
+							// gets an app that connects and reports no callable
+							// actions. Excluding it never made a build safer; it
+							// only made that failure reachable.
+							//
+							// It is ~300 lines of our own code with no library
+							// behind it, and applies_to() already no-ops when
+							// SessionManager is absent, so it costs a .org build
+							// nothing. Unlike the updater, its absence is not a
+							// guarantee we are making to anyone.
 							// WP.org listing assets — go to SVN assets/, never in the zip.
 							'!.wordpress.org/**',
 							// Lint config — dev-only.
@@ -257,11 +274,20 @@ module.exports = function ( grunt ) {
 			}
 
 			if ( 'selfhosted' === channel ) {
-				// Put the updater back by appending an un-negated pattern after
-				// the exclusion — grunt-contrib-copy applies src patterns in
-				// order, so the later include wins.
+				// Put the self-hosted-only files back by appending un-negated
+				// patterns after the exclusions — grunt-contrib-copy applies src
+				// patterns in order, so the later include wins.
+				//
+				// The adapter belongs here and did not arrive with the updater:
+				// the exclusion list has said "re-include it there the same way
+				// that branch re-includes the updater" since the channel landed,
+				// and this branch only ever pushed the updater (#111). Every
+				// build shipped so far therefore runs the JSON-RPC transport
+				// unless the site installs the official adapter plugin itself.
 				const files = grunt.config.get( 'copy.dist.files' );
 				files[ 0 ].src.push( 'includes/class-saddle-updater.php' );
+				files[ 0 ].src.push( 'includes/lib/**' );
+				files[ 0 ].src.push( 'includes/class-saddle-bundled-adapter.php' );
 				grunt.config.set( 'copy.dist.files', files );
 			}
 

--- a/includes/class-saddle-mcp-diagnostics.php
+++ b/includes/class-saddle-mcp-diagnostics.php
@@ -44,6 +44,29 @@ class Saddle_MCP_Diagnostics {
 	const TRACE_OPTION = 'saddle_mcp_trace';
 
 	/**
+	 * Whether the adapter path is running without Saddle_MCP_Compat.
+	 *
+	 * Set during transport setup and merged into the health record by
+	 * {@see self::record_health()}. It is request state, not stored state: the
+	 * next request re-derives it from whether the class loaded.
+	 *
+	 * @var bool
+	 */
+	private static $compat_missing = false;
+
+	/**
+	 * Note that the adapter is serving requests without its compatibility shim.
+	 *
+	 * This is a build fault, not a configuration one — the shim was excluded
+	 * from every zip for a month while the adapter path stayed reachable through
+	 * the official MCP Adapter plugin, and the only outward symptom was a client
+	 * connecting and then finding no callable tools (#111).
+	 */
+	public static function note_compat_missing() {
+		self::$compat_missing = true;
+	}
+
+	/**
 	 * Option holding the unix timestamp recording stops at.
 	 */
 	const RECORDING_OPTION = 'saddle_mcp_trace_until';
@@ -152,6 +175,14 @@ class Saddle_MCP_Diagnostics {
 	public static function record_health( array $facts ) {
 		$facts['recorded_at'] = time();
 		$facts['init_fired']  = did_action( 'init' ) > 0;
+
+		// Merged into every write rather than recorded on its own, because this
+		// option is replaced wholesale and the adapter writes it later in the
+		// request than the point where the shim's absence is discovered.
+		if ( self::$compat_missing ) {
+			$facts['compat_missing'] = true;
+			$facts['degraded']       = true;
+		}
 
 		$previous = get_option( self::HEALTH_OPTION );
 		if ( is_array( $previous ) ) {

--- a/saddle.php
+++ b/saddle.php
@@ -290,10 +290,23 @@ final class Saddle {
 			// it. Reached only when that plugin is present.
 			add_action( 'mcp_adapter_init', array( 'Saddle_MCP', 'register_adapter_server' ) );
 
-			// Shims the adapter's session and protocol-header strictness; it has
-			// no purpose without the adapter, so it ships with it.
+			// Shims the adapter's session and protocol-header strictness.
+			//
+			// The guard stays — it is the house rule — but it no longer fails
+			// quietly. This exact class_exists() returned false in every build
+			// for a month because the zip excluded the file, and the only
+			// symptom reachable from outside was ChatGPT reporting that the
+			// site has no callable actions (#111). A guard whose false branch
+			// is invisible is how that lasted, so the false branch now says so
+			// where the owner and a support conversation can both see it.
 			if ( class_exists( 'Saddle_MCP_Compat' ) ) {
 				Saddle_MCP_Compat::register();
+			} else {
+				// Noted, not recorded: the health record is rewritten wholesale
+				// on mcp_adapter_init, a few hooks later, so anything written
+				// here would be erased on precisely the sites where the adapter
+				// is present — the only sites where this matters.
+				Saddle_MCP_Diagnostics::note_compat_missing();
 			}
 		} else {
 			add_action( 'rest_api_init', array( 'Saddle_MCP', 'register_routes' ) );


### PR DESCRIPTION
Closes #113

## What

Reverts one half of #112. The shim half stands and is untouched: `class-saddle-mcp-compat.php` still ships on both channels, which is the fix for #111.

What this removes is #112's second change — re-adding `includes/lib/**` and `class-saddle-bundled-adapter.php` to the self-hosted channel. **Net diff against `main` is `Gruntfile.js` only.**

## Why

#112 acted on a comment in the exclusion list: *"When the self-hosted channel lands, re-include it there the same way that branch re-includes the updater."* That comment predates the work that made it wrong.

`Saddle_MCP`'s own JSON-RPC transport was brought into Streamable-HTTP conformance in #97 — the 202-with-no-body notification ack, GET/DELETE 405, the protocol-version 400, empty `resources`/`prompts` lists — and the stated reason was that ".org has no adapter, so that transport is the only one a .org install will ever have."

Given that, bundling the library into self-hosted builds trades away the more valuable property: **self-hosted is the .org artifact plus an updater, one file.** A customer testing a build is testing what .org ships. Diverging the two in the *transport* is diverging them in the exact subsystem that has produced every customer bug so far — and the self-hosted zip is what goes to testers.

It also costs about half the zip (~347 of 464 files) and carries the only `error_log`/`fwrite` calls in the tree.

Orthogonal to #111 either way: `adapter_available()` tests for `\WP\MCP\Core\McpAdapter` from any source, so a site with the official MCP Adapter plugin takes the adapter path on every channel regardless. That is why the shim ships everywhere.

## Testing

- [x] `composer test` — 594 tests, 1986 assertions, 1 pre-existing skip, green
- [x] `composer lint` — 0 errors (1 pre-existing warning in `class-saddle-render.php`, untouched)
- [x] `npm run lint:js` — clean
- [x] Bundle unchanged; this PR touches no `admin/src`
- [x] **Verified on both built artifacts:**
  - `grunt build` → **120 files**, shim present, `lib/wp-mcp` **0**, no updater
  - `grunt build --channel=selfhosted` → **121 files**, shim present, `lib/wp-mcp` **0**, updater present
  - Exactly one file apart, which is the invariant this PR protects.