### PR TITLE
fix: keep the vendored adapter out of the self-hosted channel (#113)

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -124,9 +124,13 @@ module.exports = function ( grunt ) {
 							// installs the official MCP Adapter plugin gets the
 							// adapter path back automatically.
 							//
-							// Keep this exclusion in the WordPress.org build. When
-							// the self-hosted channel lands, re-include it there the
-							// same way that branch re-includes the updater.
+							// Excluded on BOTH channels, not just .org. The earlier
+							// plan was to re-include it for self-hosted; that was
+							// written before Saddle_MCP's own transport was hardened
+							// as the one a .org install will ever have, and shipping
+							// a different transport to testers than to .org users
+							// costs us the field evidence we most need. Tracked as
+							// its own decision in #113.
 							'!includes/lib/**',
 							// The loader that declares the library's own reserved
 							// WP_MCP_* constants. Useless without the library, and
@@ -152,6 +156,7 @@ module.exports = function ( grunt ) {
 							// SessionManager is absent, so it costs a .org build
 							// nothing. Unlike the updater, its absence is not a
 							// guarantee we are making to anyone.
+							//
 							// WP.org listing assets — go to SVN assets/, never in the zip.
 							'!.wordpress.org/**',
 							// Lint config — dev-only.
@@ -274,20 +279,23 @@ module.exports = function ( grunt ) {
 			}
 
 			if ( 'selfhosted' === channel ) {
-				// Put the self-hosted-only files back by appending un-negated
-				// patterns after the exclusions — grunt-contrib-copy applies src
-				// patterns in order, so the later include wins.
+				// Put the updater back by appending an un-negated pattern after
+				// the exclusion — grunt-contrib-copy applies src patterns in
+				// order, so the later include wins.
 				//
-				// The adapter belongs here and did not arrive with the updater:
-				// the exclusion list has said "re-include it there the same way
-				// that branch re-includes the updater" since the channel landed,
-				// and this branch only ever pushed the updater (#111). Every
-				// build shipped so far therefore runs the JSON-RPC transport
-				// unless the site installs the official adapter plugin itself.
+				// The updater is the ONLY difference between the two channels,
+				// and that is the invariant to protect: a self-hosted build is
+				// the .org artifact plus an update check, so a customer testing
+				// a build is testing what .org ships. The exclusion list above
+				// asks for the vendored adapter to be re-added here too — that
+				// predates the JSON-RPC transport being hardened as the one a
+				// .org install will ever have, and re-adding it would make the
+				// tester's transport differ from the shipped one in the exact
+				// subsystem we most need field evidence about. #112 acted on
+				// that comment; this reverts that half and leaves it as its own
+				// decision (#113). The shim half of #112 stands.
 				const files = grunt.config.get( 'copy.dist.files' );
 				files[ 0 ].src.push( 'includes/class-saddle-updater.php' );
-				files[ 0 ].src.push( 'includes/lib/**' );
-				files[ 0 ].src.push( 'includes/class-saddle-bundled-adapter.php' );
 				grunt.config.set( 'copy.dist.files', files );
 			}
 


### PR DESCRIPTION
Closes #113

Replaces #114, which carried #112's already-squashed commit and conflicted once #116 landed. Identical `Gruntfile.js` diff, single commit, clean off `main`.

## What

Reverts one half of #112. The shim half stands and is untouched — `class-saddle-mcp-compat.php` still ships on both channels, which is the fix for #111. What this removes is #112's second change: re-adding `includes/lib/**` and `class-saddle-bundled-adapter.php` to the self-hosted channel.

**Net diff is `Gruntfile.js` only.**

## Why

#112 acted on a comment in the exclusion list: *"When the self-hosted channel lands, re-include it there the same way that branch re-includes the updater."* That comment predates the work that made it wrong.

`Saddle_MCP`'s own JSON-RPC transport was brought into Streamable-HTTP conformance in #97 — the 202-with-no-body notification ack, GET/DELETE 405, the protocol-version 400, empty `resources`/`prompts` lists — and the stated reason was that ".org has no adapter, so that transport is the only one a .org install will ever have."

Given that, bundling the library into self-hosted builds trades away the more valuable property: **self-hosted is the .org artifact plus an updater, one file.** A customer testing a build is testing what .org ships. Diverging the two in the *transport* is diverging them in the exact subsystem that has produced every customer bug so far — and the self-hosted zip is the one that goes to testers.

It also costs about half the zip (~347 of 464 files) and carries the only `error_log`/`fwrite` calls in the tree.

Orthogonal to #111 either way: `adapter_available()` tests for `\WP\MCP\Core\McpAdapter` from any source, so a site with the official MCP Adapter plugin takes the adapter path on every channel regardless. That is why the shim ships everywhere.

## Testing

- [x] `composer test` — 596 tests, green
- [x] `composer lint` — 0 errors (pre-existing warnings only)
- [x] `npm run lint:js` — clean
- [x] Bundle untouched; this PR changes no `admin/src`
- [x] **Verified on both built artifacts:**
  - `grunt build` → **120 files**, shim present, `lib/wp-mcp` **0**, no updater
  - `grunt build --channel=selfhosted` → **121 files**, shim present, `lib/wp-mcp` **0**, updater present
  - Exactly one file apart, which is the invariant this PR protects.