### PR TITLE
chore: build 1.0.0-rc6 for testing

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -262,6 +262,28 @@ module.exports = function ( grunt ) {
 				JSON.stringify( pkg, null, '\t' ) + '\n'
 			);
 
+			// package-lock.json: BOTH copies. It carries the version at the root
+			// and again under packages[''], and this task wrote neither — so
+			// the lockfile silently kept the previous version while the other
+			// four sites moved, which is exactly the drift the "five places
+			// must agree" rule exists to prevent.
+			//
+			// Addressed structurally, NOT by a text substitution. Every
+			// dependency in this file has a "version" field too, and a global
+			// regex for `"version": "<semver>"` rewrites all of them to the
+			// plugin's version. Only these two keys mean the plugin.
+			if ( grunt.file.exists( 'package-lock.json' ) ) {
+				const lock = grunt.file.readJSON( 'package-lock.json' );
+				lock.version = to;
+				if ( lock.packages && lock.packages[ '' ] ) {
+					lock.packages[ '' ].version = to;
+				}
+				grunt.file.write(
+					'package-lock.json',
+					JSON.stringify( lock, null, '\t' ) + '\n'
+				);
+			}
+
 			grunt.log.ok( 'Version ' + from + ' → ' + to );
 		}
 	);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "saddle",
-	"version": "1.0.0-rc5",
+	"version": "1.0.0-rc6",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "saddle",
-			"version": "1.0.0-rc5",
+			"version": "1.0.0-rc6",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@plugpress/ui": "^0.12.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "saddle",
-	"version": "1.0.0-rc5",
+	"version": "1.0.0-rc6",
 	"description": "Self-hosted MCP server for WordPress — admin UI build.",
 	"author": "PlugPress",
 	"license": "GPL-2.0-or-later",

--- a/readme.txt
+++ b/readme.txt
@@ -143,6 +143,8 @@ If you happen to have the separate MCP Adapter plugin active, Saddle notices and
 
 = 1.0.0 =
 * Initial public release.
+* Fixed: on sites that also run the separate MCP Adapter plugin, an app could finish connecting and then report that the site has no actions it can use. The piece that prevents that was missing from the plugin package, so the fix for it had never actually reached anyone. It now ships.
+* Connection details and health now reports what it knows on every site, not only on sites running the separate MCP Adapter plugin. It previously opened with "No app has connected yet" no matter what had happened, which made the request recorder underneath it look broken — and that recorder is the thing that shows whether a connected app's requests are arriving and what they got back.
 * The guidance an assistant reads when it connects is now one document with one set of headings, however many PlugPress plugins are adding to it. Previously each plugin appended in its own style — one added a heading two levels down, another a bare sentence with no heading at all — and it read like four notes stapled together.
 * Removed a second web address the plugin was serving without saying so. Saddle publishes one address for AI apps; a bundled library was quietly adding another with weaker checks around it. Nothing documented ever pointed at it, and your access levels and confirmations applied there too — but it should not have existed, and now it doesn't.
 * Permissions now tells you how many tools your connected apps are actually offered at the level you pick, how many are being held back, and that already-connected apps keep the old list until you refresh or reopen them.

--- a/saddle.php
+++ b/saddle.php
@@ -3,7 +3,7 @@
  * Plugin Name:       Saddle – Control Your Site with AI (MCP Server)
  * Plugin URI:        https://plugpress.co/saddle/
  * Description:       Self-hosted MCP server for WordPress. Tiered, default-safe, approval-gated access to posts, pages, and media for AI agents — with no third-party credential custody.
- * Version:           1.0.0-rc5
+ * Version:           1.0.0-rc6
  * Requires at least: 6.9
  * Requires PHP:      7.4
  * Author:            PlugPress
@@ -18,7 +18,7 @@
 
 defined( 'ABSPATH' ) || exit;
 
-define( 'SADDLE_VERSION', '1.0.0-rc5' );
+define( 'SADDLE_VERSION', '1.0.0-rc6' );
 define( 'SADDLE_FILE', __FILE__ );
 define( 'SADDLE_DIR', plugin_dir_path( __FILE__ ) );
 define( 'SADDLE_URL', plugin_dir_url( __FILE__ ) );


### PR DESCRIPTION
## What

Bumps to `1.0.0-rc6` and fixes the version task, which was skipping one of the five places the version lives.

## Why

**rc5 does not contain the ChatGPT fix.** It was built at 14:14 UTC on 2026-08-17; #112 merged at 18:30 the same day. Verified in the artifact: `dist/saddle-1.0.0-rc5.zip` has no `class-saddle-mcp-compat.php`. So the shim that exists specifically so ChatGPT can discover tools is on `main` and has still never been in anyone's hands — which is the second time that has happened to this same fix.

rc6 carries it, plus #116 (the Client traffic card no longer opens with "No app has connected yet" on every build we ship) and #117.

## The version task

It wrote the plugin header, `SADDLE_VERSION`, `readme.txt` and `package.json` — and never touched `package-lock.json`, so the lockfile stayed at the previous version after every bump. CLAUDE.md lists all five as having to agree; four of them did.

Fixed **structurally, not by text substitution**: every dependency in a lockfile carries its own `"version"` field, so a global regex for `"version": "<semver>"` rewrites all of them to the plugin's version. This sets `lock.version` and `lock.packages[''].version` and nothing else — verified as a 2-line diff with no dependency churn.

## Changelog

Entries for #112 and #116 added under `= 1.0.0 =` in customer-facing language. `Stable tag` stays at `1.0.0` — it never moves for a release candidate.

## Testing

- [x] `composer test` — 596 tests, green
- [x] `composer lint` — 0 errors; `npm run lint:js` clean
- [x] `php scripts/revendor-wp-mcp.php --check` — clean, exit 0
- [x] Execution-function grep — zero real hits outside `includes/lib` (three matches are the word "system" inside translated prose)
- [x] All five version sites agree; `Stable tag` correctly held at `1.0.0`
- [x] **Both artifacts built and inspected:**

| | `.org` | `-selfhosted` |
|---|---|---|
| files | 120 | 121 |
| `class-saddle-mcp-compat.php` | present | present |
| `class-saddle-updater.php` | **absent** | present |
| `lib/wp-mcp` | 0 files | 0 files |
| `class-saddle-ecosystem.php` | absent | absent |
| `tests/`, `dist/`, `*.md` | 0 | 0 |

- [x] Both fixes confirmed *inside* the zip, not just in the tree — the new health copy in `admin/build/index.js`, `record_health` in `includes/class-saddle-mcp.php`
- [ ] Plugin Check against the built zip — not run this session
- [ ] Not published to R2. `./scripts/release.sh` is a separate, outward-facing step and is Fahim's call.