### PR TITLE
chore: build 1.0.0-rc8 for testing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "saddle",
-	"version": "1.0.0-rc7",
+	"version": "1.0.0-rc8",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "saddle",
-			"version": "1.0.0-rc7",
+			"version": "1.0.0-rc8",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@plugpress/ui": "^0.12.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "saddle",
-	"version": "1.0.0-rc7",
+	"version": "1.0.0-rc8",
 	"description": "Self-hosted MCP server for WordPress — admin UI build.",
 	"author": "PlugPress",
 	"license": "GPL-2.0-or-later",

--- a/saddle.php
+++ b/saddle.php
@@ -3,7 +3,7 @@
  * Plugin Name:       Saddle – Control Your Site with AI (MCP Server)
  * Plugin URI:        https://plugpress.co/saddle/
  * Description:       Self-hosted MCP server for WordPress. Tiered, default-safe, approval-gated access to posts, pages, and media for AI agents — with no third-party credential custody.
- * Version:           1.0.0-rc7
+ * Version:           1.0.0-rc8
  * Requires at least: 6.9
  * Requires PHP:      7.4
  * Author:            PlugPress
@@ -18,7 +18,7 @@
 
 defined( 'ABSPATH' ) || exit;
 
-define( 'SADDLE_VERSION', '1.0.0-rc7' );
+define( 'SADDLE_VERSION', '1.0.0-rc8' );
 define( 'SADDLE_FILE', __FILE__ );
 define( 'SADDLE_DIR', plugin_dir_path( __FILE__ ) );
 define( 'SADDLE_URL', plugin_dir_url( __FILE__ ) );


### PR DESCRIPTION
Version bump only — the five version locations move to 1.0.0-rc8 (stable tag stays 1.0.0, as always for an rc). Carries the #127 fix (PR #128) so Mark can retest ChatGPT on staging.kesuk.net.

Approved by Fahim in-session (merge + rc8 build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016dGNUUe36hKi5o9hzFb3Cb