### PR TITLE
chore(oauth): annotate core rest_url filter for Plugin Check

### DIFF
--- a/includes/oauth/class-saddle-oauth.php
+++ b/includes/oauth/class-saddle-oauth.php
@@ -250,6 +250,7 @@ class Saddle_OAuth {
 		}
 
 		/** This filter is documented in wp-includes/rest-api.php */
+		// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- Core's own rest_url filter, applied with core's argument shape so the pre-init replica stays byte-identical to get_rest_url().
 		return apply_filters( 'rest_url', $url, $path, null, 'rest' );
 	}
 


### PR DESCRIPTION
One phpcs:ignore comment, no behavior change. Plugin Check (run against the built 1.0.0 zip for the .org submission) warns that `apply_filters( 'rest_url', … )` in the new `rest_url_early()` is a non-prefixed hook name. It is core's own filter, applied deliberately with core's exact argument shape so the pre-`init` replica stays byte-identical to `get_rest_url()` (see #127 / #128). The annotation states that so the warning disappears from the submission scan.

Verified: `composer lint` clean; re-ran Plugin Check on the rebuilt zip — the `rest_url` warning is gone, only the two pre-existing warnings (vendored adapter hook in mcp-compat, dynamic hooks in the integration engine) remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016dGNUUe36hKi5o9hzFb3Cb