### PR TITLE
chore: tested up to 7.1

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: badhonrocks
 Tags: mcp, ai, application passwords, agents, automation
 Requires at least: 6.9
-Tested up to: 7.0
+Tested up to: 7.1
 Requires PHP: 7.4
 Stable tag: 1.0.0
 License: GPLv2 or later


### PR DESCRIPTION
One-line readme bump. The WordPress.org upload failed automated scanning on `outdated_tested_upto_header` (Tested up to: 7.0 < 7.1) — the one Plugin Check ERROR already flagged in this week's pre-submission run. Verification against 7.1: the SQLite-backed suite runs against the WP 7.1 install at wp/plug-press (612 tests green), and both WP Playground verifications resolved "latest" to wordpress-7.1.zip. Fahim approved the bump in-session after the automated rejection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016dGNUUe36hKi5o9hzFb3Cb