### PR TITLE
chore: drop the application-passwords readme tag

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1,6 +1,6 @@
 === Saddle – Control Your Site with AI (MCP Server) ===
 Contributors: badhonrocks
-Tags: mcp, ai, application passwords, agents, automation
+Tags: mcp, ai, agents, automation
 Requires at least: 6.9
 Tested up to: 7.1
 Requires PHP: 7.4


### PR DESCRIPTION
Removes "application passwords" from the readme Tags line per Fahim — it described the auth mechanism, not what the plugin does, and tag lists work best as discovery terms. Four tags remain: mcp, ai, agents, automation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016dGNUUe36hKi5o9hzFb3Cb