### PR TITLE
chore: add chatgpt readme tag

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1,6 +1,6 @@
 === Saddle – Control Your Site with AI (MCP Server) ===
 Contributors: badhonrocks
-Tags: mcp, ai, agents, automation
+Tags: mcp, ai, chatgpt, agents, automation
 Requires at least: 6.9
 Tested up to: 7.1
 Requires PHP: 7.4


### PR DESCRIPTION
Adds "chatgpt" to the readme Tags line per Fahim — it is the client people search by, and the plugin's OAuth server exists specifically for it. Back at the five-tag limit: mcp, ai, chatgpt, agents, automation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016dGNUUe36hKi5o9hzFb3Cb