### PR TITLE
chore: drop the unreachable duplicates in denial_reason() (#151)

### DIFF
--- a/includes/class-saddle-capabilities.php
+++ b/includes/class-saddle-capabilities.php
@@ -506,25 +506,6 @@ class Saddle_Capabilities {
 			);
 		}
 
-		if ( 'read' !== $required && '' !== $required && self::is_domain_enforced() && ! self::domain_matches_recorded() ) {
-			return array(
-				'code'    => 'saddle_domain_drift',
-				'message' => __( 'This site\'s domain changed since write access was granted, and the owner has domain enforcement on — write tools are refused until they re-confirm the access level (Saddle → Permissions). Do not retry; tell the user.', 'saddle' ),
-			);
-		}
-
-		if ( '' !== $required && ! self::tier_allows( $required ) ) {
-			return array(
-				'code'    => 'saddle_tier_denied',
-				'message' => sprintf(
-					/* translators: 1: required access level, 2: current access level. */
-					__( 'This tool needs the "%1$s" access level, but this site allows "%2$s". Only the site owner can raise it (Saddle → Permissions). Do not retry — ask the user to change the level if they want this done.', 'saddle' ),
-					$required,
-					self::get_tier()
-				),
-			);
-		}
-
 		return null;
 	}
 


### PR DESCRIPTION
Closes #151

## What

Deletes 19 unreachable lines at the end of `Saddle_Capabilities::denial_reason()`.

## Why

The function ended with verbatim copies of two branches it had already run:

- The second domain-drift condition is **character-identical** to the first. If it were true, the function already returned `saddle_domain_drift`.
- The second tier-denied condition is **character-identical** to the first. If it were true, the function already returned `saddle_insufficient_scope` or `saddle_tier_denied` — that block has no fall-through path.
- `$required` is assigned before both, and nothing between them touches it, `$gate`, or any state either condition reads.

This is worth deleting rather than ignoring, because the duplicate tier block is a **worse** version of the one that runs — it omits the `saddle_insufficient_scope` branch. If it ever became reachable it would tell an OAuth-scope-limited agent to go raise the site's access level, which is the wrong screen, and is exactly the bug #108 fixed. A stale copy of a corrected code path sitting next to the corrected one is how that regression comes back.

Found while reading `denial_reason()` for #148, and kept out of that PR so the security diff stays reviewable.

## Testing

- [x] `composer test` — 612 tests, unchanged. No new test: unreachable code cannot change behaviour, and the proof nothing moved is `capabilities-test.php`'s existing gate-ordering coverage staying green.
- [x] `composer lint` — 0 errors
- [x] `php -l` clean

**CI note:** `main` is red on `Saddle_Skills_Test::test_the_playbook_adapts_step_two_to_a_classic_theme` (#145, CI-only, green locally). This branch inherits it; unrelated to this diff.
