### PR TITLE
docs(wporg): answer round 2 where a re-scan reads it (#161)

### DIFF
--- a/WPORG-SUBMISSION.md
+++ b/WPORG-SUBMISSION.md
@@ -1,7 +1,7 @@
 # WordPress.org submission — checklist & reviewer notes
 
 Internal doc (never shipped in the zip — excluded in Gruntfile.js). Last audit:
-2026-07-28, responding to review round 1.
+2026-08-27, responding to review round 2.
 
 ## Review history
 
@@ -12,6 +12,14 @@ Review ID `AUTOPREREVIEW ❗TRM saddle/badhonrocks/25Jul26/T1 25Jul26/4.2A1
 proportions"), so several items were pattern-match flags rather than findings.
 Five flags; two were real. All addressed 2026-07-28 — see §8–§11 below for the
 answers, which are the ones to reuse if round 2 asks again.
+
+### Round 2 — pended 2026-08-24
+
+Two flags. **One was real and is fixed** (per-object read authorization, §13);
+**one is a false positive from the reviewer's URL checker** and needs an
+explanation rather than a change (§14). Both answers below are written to be
+reusable verbatim if a round 3 raises them again — the second one especially,
+because nothing in this plugin can make it stop being flagged.
 
 ## Submitting
 
@@ -307,3 +315,236 @@ connected app can never do more than the owner already allowed, and usually less
 
 Covered by 60 tests across `tests/oauth-flow-test.php`,
 `tests/oauth-bearer-test.php`, and `tests/oauth-discovery-test.php`.
+
+### 13. Per-object read authorization (round 2 blocker — fixed)
+
+**Flagged:** `saddle/get-media`, quoted from
+`includes/abilities/core-content.php`, with the note that the
+`permission_callback` "only checks the generic read capability, while
+`get_media` returns any attachment's metadata and URL without a per-attachment
+`read_post` authorization check."
+
+**The finding is correct, and it was five abilities wider than the line they
+cited.** The reason it generalizes: read-tier abilities pass `$cap = 'read'`,
+which **every logged-in user holds including a Subscriber**; any logged-in user
+can mint a core Application Password; and the MCP route requires only
+`is_user_logged_in()`. So the permission callback proved the caller was signed
+in and nothing more, across the whole read surface. (The write side has guarded
+against exactly this since day one, in `authorize_write()`.)
+
+Six gaps, all closed: `get-media`, `get-post` / `get-page`,
+`list-post-revisions`, `list-posts` / `list-pages`, `search-content`,
+`list-media`.
+
+**Authorization is two layers, and only the first is in the
+`permission_callback`.** This is documented at the top of
+`includes/abilities/core-content.php` and pointed at from every affected
+registration, so the split is legible at the line a scan quotes:
+
+| Layer | Where | Answers |
+|---|---|---|
+| Tool | `Saddle_Capabilities::permission( $tier, $cap, $tool )` | May this caller use this tool at all — authenticated, site access tier, generic capability, per-tool switch, global pause |
+| Object | `Saddle_Abilities::require_readable_post()` / `::collection()` | May this caller read *this* row |
+
+The object layer is on the execute path rather than in the gate on purpose.
+Core does pass `$input` to `WP_Ability::check_permissions()` and accepts a
+`WP_Error` back, but `Saddle_Capabilities::denial_reason()` and
+`is_callable_now()` — which build `tools/list` and every refusal message an
+agent reads — are input-free by construction, and a gate that answered "no"
+without naming which layer said so is what puts an agent into a retry loop.
+It is called *first* in every id-taking read callback, before the row is
+touched.
+
+**What each control does:**
+
+- `require_readable_post()` resolves the id, rejects a wrong post type, then
+  requires `read_post` on the object. For an attachment that is the whole
+  mechanism: `read_post` resolves an `inherit` status through
+  `get_post_status()`, which follows `post_parent`, so an upload on a draft or
+  private post is refused and a parentless one stays readable — exactly how
+  core's own media endpoint behaves.
+- **Password-protected posts refuse rather than blank.** `map_meta_cap` never
+  consults `post_password`; core blanks the content at render time instead.
+  Saddle returns *raw* `post_content`, which core only hands out in the edit
+  context, behind `WP_REST_Posts_Controller::can_access_password_content()` —
+  so the threshold here is core's own `edit_post`. It refuses rather than
+  blanks because this reader feeds a writer on the same id, and an agent handed
+  `content: ""` concludes the page is empty and rebuilds it.
+- `list-post-revisions` additionally requires `edit_post`, matching
+  `WP_REST_Revisions_Controller::get_items_permissions_check()`. Being able to
+  read a post is not being able to read the drafts it went through.
+- Listings gate the *requested status* on the post type's `edit_posts`
+  (core's `sanitize_post_statuses()`), then drop rows failing `read_post` in
+  `collection()` (core's `get_items()`). Both are needed: an Author holds
+  `edit_posts` and may legitimately ask for drafts, and must still not receive
+  another author's.
+- **One deliberate divergence from core, narrated rather than silent.**
+  Filtering after the query leaves `total` counting rows that were not
+  returned. Core accepts that silently, because recounting means a second
+  unbounded query. Saddle adds a `note` to the response instead, because an
+  agent handed a short page with no explanation retries it. It never fires for
+  an administrator, so that response shape is unchanged for the normal setup.
+- The same class of gap was swept for and closed in the activity log too:
+  `recall-changes` and the "recent changes" section of the system context now
+  filter each row against the object it names
+  (`Saddle_Log::entry_is_visible()`).
+
+**`get-preview-url` is deliberately stricter and does not use the shared
+funnel.** A preview link renders unpublished content on the front end, so an
+unpublished post needs `edit_post` there, not `read_post`.
+
+**Tests:** `tests/read-authorization-test.php` — 39 cases driving the real
+`wp_get_ability()->execute()` path an MCP client hits. Roughly half of them are
+the administrator half of the contract: the normal Saddle setup is an owner's
+administrator Application Password, and nothing about it may change. The core
+behaviours this leans on (`read_post` following `post_parent` for `inherit`)
+are pinned separately, so a core release surfaces as a red test rather than a
+support email.
+
+**Verified on a live install, not only in the suite.** Two Application
+Passwords (administrator + a throwaway subscriber) against a private post, a
+draft, and an attachment on the private post. Subscriber: 403 with a named
+reason on `get-post`, `get-media` and `list-post-revisions`, and a named
+refusal on `list-posts status=draft`; listings returned `publish` only.
+Administrator: everything, `status=draft` still works, and no `note` key.
+
+### 14. The Unsplash URL 401 (round 2 — a false positive in the checker)
+
+**Flagged:** "Terms/Privacy URL: `https://unsplash.com/api-terms` — readme.txt —
+This URL replies us with a 401 HTTP code, meaning that it does not work or is
+not public."
+
+**The page is public. `unsplash.com` sits behind Anubis** (the `within.website`
+anti-scraping proof-of-work challenge) and serves a challenge to any
+user-agent containing `Mozilla`. A human browser solves it and reads the page;
+a checker that does not run the challenge JavaScript sees the 401.
+
+Reproduction — same URL, two user agents:
+
+```console
+$ curl -sI -A 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 \
+    (KHTML, like Gecko) Chrome/120.0 Safari/537.36' https://unsplash.com/api-terms
+HTTP/2 307
+location: /.within.website?redir=%2Fapi-terms
+    → 401 Authorization required
+
+$ curl -s -o /dev/null -w '%{http_code}\n' -A 'curl/8.4.0' https://unsplash.com/api-terms
+200
+```
+
+Deterministic across repeated runs on 2026-08-25 and 2026-08-27.
+
+**It is not limited to the flagged path.** Every `unsplash.com` path behaves
+identically, including one that was **not** flagged:
+
+| URL | browser UA | `curl` UA |
+|---|---|---|
+| `https://unsplash.com/api-terms` | 401 | 200 |
+| `https://unsplash.com/privacy` | 401 | 200 |
+| `https://unsplash.com/terms` | 401 | 200 |
+| `https://unsplash.com/license` | 401 | 200 |
+| `https://help.unsplash.com/en/articles/2511245-unsplash-api-guidelines` | 200 | 200 |
+
+So swapping only the flagged URL would leave the identical landmine on the
+privacy link, and there is **no** browser-reachable canonical Unsplash terms or
+privacy URL to swap to. Both canonical URLs therefore stay — guideline 6 asks
+for the service's actual terms and privacy policy, and Unsplash's privacy
+policy exists nowhere else — with Unsplash's own help-centre API guidelines
+page, which answers 200 to everything, listed first alongside them.
+
+**Context for how little this reaches a user.** The Unsplash integration is off
+until the site owner pastes their own Unsplash Access Key on the Integrations
+screen. With no key saved, no request is ever made and the two tools are not
+offered. The disclosure exists because the integration can be turned on, not
+because it is on.
+
+## Draft reply — round 2
+
+Not sent. Re-run the two `curl` commands in §14 on the day it goes out, so the
+transcript in the mail is current rather than quoted from here.
+
+---
+
+Thanks for the review — both items below, with the second one needing an
+explanation rather than a change.
+
+**1. `permission_callback` on `saddle/get-media`**
+
+You were right, and it was wider than the line you cited. Our read-tier
+abilities pass `read` as the capability, which every logged-in user holds
+including a Subscriber, so the permission callback proved the caller was signed
+in and nothing more. Six abilities were affected: `get-media`, `get-post`,
+`get-page`, `list-post-revisions`, `list-posts`/`list-pages`, `search-content`
+and `list-media`.
+
+All of them now authorize the object, not just the tool:
+
+- Every id-taking read calls `Saddle_Abilities::require_readable_post()` first,
+  before touching the row. It resolves the id, rejects a wrong post type, and
+  requires `read_post` on the object. For an attachment that resolves the
+  `inherit` status through `post_parent`, so an upload on a draft or private
+  post is refused and a parentless one stays readable — the same behaviour as
+  core's media endpoint.
+- Raw `post_content` on a password-protected post now requires `edit_post`,
+  matching `WP_REST_Posts_Controller::can_access_password_content()`, since we
+  return the raw field rather than the rendered one.
+- `list-post-revisions` additionally requires `edit_post` on the parent, the
+  same threshold as `WP_REST_Revisions_Controller`.
+- Listings gate the requested status on the post type's `edit_posts` and then
+  drop rows failing `read_post`, mirroring `sanitize_post_statuses()` and
+  `get_items()`.
+
+To make the split easy to see at the line you quoted: the `permission_callback`
+gates the *tool* (authentication, the site's access level, the generic
+capability, the per-tool switch, the pause switch) and the object check is the
+first thing the execute callback does. Both layers are now documented at the top
+of `includes/abilities/core-content.php` and pointed at from each affected
+registration. It lives on the execute path because our refusal messages have to
+name which control refused — an AI agent given an unexplained "no" retries in a
+loop — and the tool-list filter that reads the same gate has no input to check
+an object against.
+
+Covered by 39 tests that drive the real ability-execution path, about half of
+them pinning that an administrator credential — the normal setup for this
+plugin — is unaffected. We also verified it on a live install with two
+Application Passwords, an administrator and a throwaway Subscriber, against a
+private post, a draft and an attachment on the private post.
+
+**2. `https://unsplash.com/api-terms` returning 401**
+
+This one is a false positive, and unfortunately there is nothing we can change
+in the plugin to make it stop. The page is public; `unsplash.com` sits behind
+Anubis, an anti-scraping proof-of-work challenge, and serves that challenge to
+any user agent containing `Mozilla`. A browser solves it and reads the page; a
+checker that does not run the challenge script sees a 401.
+
+Same URL, two user agents:
+
+```
+$ curl -sI -A 'Mozilla/5.0 … Chrome/120.0 Safari/537.36' https://unsplash.com/api-terms
+HTTP/2 307
+location: /.within.website?redir=%2Fapi-terms      → 401 Authorization required
+
+$ curl -s -o /dev/null -w '%{http_code}\n' -A 'curl/8.4.0' https://unsplash.com/api-terms
+200
+```
+
+It affects every path on that host, including `https://unsplash.com/privacy`,
+which your check did not flag. So swapping the flagged URL for another
+`unsplash.com` page would not fix anything, and there is no
+browser-reachable canonical Unsplash terms or privacy URL to point at instead.
+We have kept both canonical links, because guideline 6 asks for the service's
+actual terms and privacy policy and Unsplash's privacy policy exists nowhere
+else, and listed Unsplash's own help-centre API guidelines page — which answers
+200 to everything — alongside them.
+
+Worth adding for context: this integration is inert until the site owner pastes
+their own Unsplash API key on our Integrations screen. With no key saved, no
+request is ever made and the two tools are not offered at all. We disclose it
+because it can be turned on, not because it is on.
+
+Happy to make any change you would prefer here — including dropping the two
+`unsplash.com` links entirely and keeping only the help-centre page, if you
+would rather the readme contain no URL your checker flags.
+
+The corrected zip is uploaded.

--- a/includes/abilities/blocks.php
+++ b/includes/abilities/blocks.php
@@ -208,6 +208,9 @@ function saddle_register_block_abilities() {
 	 * ---------------------------------------------------------------------
 	 */
 
+	// The permission_callback below gates the TOOL. The TARGET is authorized by
+	// Saddle_Abilities::require_readable_post(), called first in get_blocks() — the
+	// shared read_post funnel documented at the top of core-content.php.
 	wp_register_ability(
 		'saddle/get-blocks',
 		array(

--- a/includes/abilities/core-content.php
+++ b/includes/abilities/core-content.php
@@ -10,6 +10,30 @@
  * meta.annotations + the approval gate). Do not infer either from the callback
  * body — see CLAUDE.md.
  *
+ * AUTHORIZATION IS TWO LAYERS, AND ONLY THE FIRST IS IN THE permission_callback.
+ *
+ * `Saddle_Capabilities::permission( $tier, $cap, $tool )` answers "may this
+ * caller use this tool at all": an authenticated user, the site's access tier,
+ * the generic WordPress capability, the per-tool switch and the global pause.
+ * It deliberately does NOT answer "may this caller read THIS object", because
+ * the read tier's capability is `read` — which every logged-in user holds,
+ * a Subscriber included.
+ *
+ * That second question is `Saddle_Abilities::require_readable_post()` (below),
+ * the single funnel every id-taking read calls FIRST, before touching the row:
+ * `read_post` on the resolved object, plus a refusal for password-protected
+ * content because Saddle returns raw `post_content`, which core only ever hands
+ * out behind `edit_post`. Listings use `Saddle_Abilities::collection()`, which
+ * drops rows the caller cannot `read_post`. Anything that reaches a specific
+ * post another way is a bug.
+ *
+ * It lives on the execute path rather than in the gate on purpose. Core does
+ * pass `$input` to `WP_Ability::check_permissions()` and accepts a `WP_Error`
+ * back, but `Saddle_Capabilities::denial_reason()` and `is_callable_now()` —
+ * which build `tools/list` and every refusal message an agent reads — are
+ * input-free by construction, and a gate that answered "no" without naming
+ * which of the two layers said so is what puts an agent into a retry loop.
+ *
  * @package Saddle
  */
 
@@ -73,6 +97,10 @@ function saddle_register_abilities() {
 		)
 	);
 
+	// Listings are authorized in two places, both in Saddle_Abilities: the
+	// requested status is gated on the post type's edit_posts, and collection()
+	// then drops every row the caller cannot read_post. See the two-layer note
+	// at the top of this file.
 	wp_register_ability(
 		'saddle/search-content',
 		array(
@@ -110,6 +138,10 @@ function saddle_register_abilities() {
 	 * ---------------------------------------------------------------------
 	 */
 
+	// Listings are authorized in two places, both in Saddle_Abilities: the
+	// requested status is gated on the post type's edit_posts, and collection()
+	// then drops every row the caller cannot read_post. See the two-layer note
+	// at the top of this file.
 	wp_register_ability(
 		'saddle/list-posts',
 		array(
@@ -153,6 +185,9 @@ function saddle_register_abilities() {
 		)
 	);
 
+	// The permission_callback below gates the TOOL. The TARGET is authorized by
+	// require_readable_post(), called first in get_post(). See the two-layer
+	// note at the top of this file.
 	wp_register_ability(
 		'saddle/get-post',
 		array(
@@ -205,6 +240,10 @@ function saddle_register_abilities() {
 		)
 	);
 
+	// The permission_callback below gates the TOOL. The TARGET is authorized by
+	// require_readable_post(), called first in list_post_revisions(), which then
+	// additionally requires edit_post — revisions are the edit history, not the
+	// published artifact. See the two-layer note at the top of this file.
 	wp_register_ability(
 		'saddle/list-post-revisions',
 		array(
@@ -224,6 +263,10 @@ function saddle_register_abilities() {
 	 * ---------------------------------------------------------------------
 	 */
 
+	// Listings are authorized in two places, both in Saddle_Abilities: the
+	// requested status is gated on the post type's edit_posts, and collection()
+	// then drops every row the caller cannot read_post. See the two-layer note
+	// at the top of this file.
 	wp_register_ability(
 		'saddle/list-pages',
 		array(
@@ -253,6 +296,9 @@ function saddle_register_abilities() {
 		)
 	);
 
+	// The permission_callback below gates the TOOL. The TARGET is authorized by
+	// require_readable_post(), called first in get_page(). See the two-layer
+	// note at the top of this file.
 	wp_register_ability(
 		'saddle/get-page',
 		array(
@@ -311,6 +357,10 @@ function saddle_register_abilities() {
 	 * ---------------------------------------------------------------------
 	 */
 
+	// Listings are authorized in two places, both in Saddle_Abilities: the
+	// requested status is gated on the post type's edit_posts, and collection()
+	// then drops every row the caller cannot read_post. See the two-layer note
+	// at the top of this file.
 	wp_register_ability(
 		'saddle/list-media',
 		array(
@@ -352,6 +402,11 @@ function saddle_register_abilities() {
 		)
 	);
 
+	// The permission_callback below gates the TOOL. The TARGET is authorized by
+	// require_readable_post(), called first in get_media() — read_post against
+	// the attachment, which resolves an `inherit` status through post_parent, so
+	// an upload on a draft or private post is refused. See the two-layer note at
+	// the top of this file.
 	wp_register_ability(
 		'saddle/get-media',
 		array(

--- a/includes/abilities/lint.php
+++ b/includes/abilities/lint.php
@@ -18,6 +18,9 @@ defined( 'ABSPATH' ) || exit;
  */
 function saddle_register_lint_abilities() {
 
+	// The permission_callback below gates the TOOL. The TARGET is authorized by
+	// Saddle_Abilities::require_readable_post(), called first in lint_page() — the
+	// shared read_post funnel documented at the top of core-content.php.
 	wp_register_ability(
 		'saddle/lint-page',
 		array(

--- a/includes/abilities/render.php
+++ b/includes/abilities/render.php
@@ -19,6 +19,9 @@ defined( 'ABSPATH' ) || exit;
  */
 function saddle_register_render_abilities() {
 
+	// The permission_callback below gates the TOOL. The TARGET is authorized by
+	// Saddle_Abilities::require_readable_post(), called first in render_node() — the
+	// shared read_post funnel documented at the top of core-content.php.
 	wp_register_ability(
 		'saddle/render-node',
 		array(
@@ -53,6 +56,11 @@ function saddle_register_render_abilities() {
 		)
 	);
 
+	// The permission_callback below gates the TOOL. The TARGET is authorized in
+	// get_preview_url() itself, deliberately NOT through the shared funnel: a
+	// preview link renders unpublished content on the front end, so an
+	// unpublished post needs edit_post rather than read_post. Stricter than the
+	// funnel, never looser — see the note above get_preview_url().
 	wp_register_ability(
 		'saddle/get-preview-url',
 		array(

--- a/includes/abilities/verify.php
+++ b/includes/abilities/verify.php
@@ -18,6 +18,9 @@ defined( 'ABSPATH' ) || exit;
  */
 function saddle_register_verify_abilities() {
 
+	// The permission_callback below gates the TOOL. The TARGET is authorized by
+	// Saddle_Abilities::require_readable_post(), called first in verify_page() — the
+	// shared read_post funnel documented at the top of core-content.php.
 	wp_register_ability(
 		'saddle/verify-page',
 		array(


### PR DESCRIPTION
Refs #161

Uses `Refs`, not `Closes` — #161 also covers rebuilding and re-verifying the `.org`
zip, which happens after this and #160 land.

## What

Makes Saddle's read-authorization model legible at the line the WordPress.org
reviewer quoted, and writes both round-2 answers into `WPORG-SUBMISSION.md` in a form
that can be reused verbatim if a round 3 raises them again. Comments and docs only —
no behaviour change, no new strings, nothing that ships differently.

## Why

The reviewer flagged `saddle/get-media`'s `permission_callback` for checking only the
generic `read` capability. **They were right**, and #149 fixed it — six abilities wide,
not one. But that fix routes every id-taking read through
`Saddle_Abilities::require_readable_post()` on the **execute path**, while the reviewer
quoted the **registration line**. Nothing at that line says the object is authorized
elsewhere, so an automated re-scan quotes it again and reads it the same way.

The second finding — `https://unsplash.com/api-terms` answering 401 — is a false
positive that no change to this plugin can clear, so it needs a written answer rather
than a fix.

## How

**Code comments.** A block note at the top of `includes/abilities/core-content.php`
setting out the two layers explicitly:

| Layer | Where | Answers |
|---|---|---|
| Tool | `Saddle_Capabilities::permission()` | May this caller use this tool at all |
| Object | `require_readable_post()` / `collection()` | May this caller read *this* row |

…plus a one-line pointer above each id-taking read (`get-media`, `get-post`,
`get-page`, `get-blocks`, `list-post-revisions`, `lint-page`, `render-node`,
`verify-page`) and each listing (`list-posts`, `list-pages`, `list-media`,
`search-content`).

Two things the note records that were previously only implicit:

- **Why the object check is on the execute path and not in the gate.** Core does pass
  `$input` to `WP_Ability::check_permissions()` and accepts a `WP_Error` back, so it
  *could* move — but `denial_reason()` and `is_callable_now()`, which build `tools/list`
  and every refusal an agent reads, are input-free by construction, and a gate that says
  "no" without naming which layer said so is what puts an agent into a retry loop.
- **`get-preview-url` is deliberately stricter, not outside the funnel.** A preview link
  renders unpublished content on the front end, so an unpublished post needs `edit_post`
  there rather than `read_post`.

**`WPORG-SUBMISSION.md`.** A round-2 history entry, plus:

- **§13** — the authorization model, what each control does (including the attachment
  `inherit → post_parent` resolution, the password-protected refusal and why it refuses
  rather than blanks, and the deliberate `total`-counts-dropped-rows divergence from
  core), and how it was verified on a live install.
- **§14** — the Unsplash 401, with the Anubis reproduction and a table showing that
  **every** `unsplash.com` path behaves identically, including the `/privacy` link the
  checker did **not** flag. That table is the argument: swapping the flagged URL fixes
  nothing, and there is no browser-reachable canonical Unsplash terms or privacy URL to
  swap to.
- A **draft reply**, not sent, ending with an explicit offer to drop both `unsplash.com`
  links if the reviewer would rather the readme contain no URL their checker flags.

## Testing

- [x] `composer lint` — 0 errors (3 pre-existing warnings, none in the changed files).
- [x] `composer test` — unchanged; the read-authorization suite still passes.
- [x] Unsplash reproduction re-run 2026-08-27, deterministic. `unsplash.com/api-terms`,
      `/privacy`, `/terms` and `/license` all `401` to a browser UA and `200` to `curl`;
      `help.unsplash.com` answers `200` to both.
- [x] No notices or warnings with `WP_DEBUG` on.

`WPORG-SUBMISSION.md` is excluded from both zips (root `*.md` in `Gruntfile.js`), so
none of the doc content ships.

## Screenshots

None — no UI change.
