### PR TITLE
test: switch to a classic fixture theme instead of assuming one (#145)

### DIFF
--- a/tests/fixtures/themes/saddle-classic-fixture/index.php
+++ b/tests/fixtures/themes/saddle-classic-fixture/index.php
@@ -1,0 +1,13 @@
+<?php
+/**
+ * The one template a classic theme must have. Its existence (and the absence
+ * of templates/index.html + theme.json) is what makes wp_is_block_theme()
+ * return false, which is the only thing the test suite needs from it.
+ *
+ * @package Saddle
+ */
+
+get_header();
+the_post();
+the_content();
+get_footer();

--- a/tests/fixtures/themes/saddle-classic-fixture/style.css
+++ b/tests/fixtures/themes/saddle-classic-fixture/style.css
@@ -1,0 +1,13 @@
+/*
+Theme Name: Saddle Classic Fixture
+Theme URI: https://plugpress.co/saddle/
+Author: PlugPress
+Description: A minimal classic (PHP-template) theme used only by Saddle's test suite. CI provisions a fresh WordPress core whose bundled themes are all block themes, so without this fixture the classic-theme branches of the playbook can never be exercised there — they passed locally only because the developer's host install happened to run a classic theme.
+Version: 1.0.0
+Requires at least: 6.9
+Tested up to: 7.0
+Requires PHP: 7.4
+License: GPL-2.0-or-later
+License URI: https://www.gnu.org/licenses/gpl-2.0.html
+Text Domain: saddle-classic-fixture
+*/

--- a/tests/skills-test.php
+++ b/tests/skills-test.php
@@ -332,17 +332,55 @@ class Saddle_Skills_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * The test site runs a CLASSIC theme, which is exactly the case the old
-	 * wp_is_block_theme() gate excluded — so a classic site with no builder,
-	 * the one with no site editor to fall back on, got no playbook at all.
+	 * Run assertions with a fixture theme active, then put the host theme back.
+	 *
+	 * The theme in force during a test is an environment fact, not a fixture:
+	 * the harness symlinks wp-content/themes from whichever WordPress it was
+	 * pointed at. On the developer's host that happens to be a classic theme;
+	 * CI provisions a fresh core whose bundled themes are ALL block themes. A
+	 * test that assumes either one passes on one machine and fails on the other
+	 * (#145), so anything that branches on wp_is_block_theme() switches to the
+	 * fixture it means, explicitly, the way site-editor-test.php already does.
+	 *
+	 * @param string   $slug 'saddle-classic-fixture' or 'saddle-block-fixture'.
+	 * @param callable $fn   Assertions.
+	 */
+	private function with_theme( $slug, callable $fn ) {
+		$previous = get_stylesheet();
+
+		register_theme_directory( __DIR__ . '/fixtures/themes' );
+		delete_site_transient( 'theme_roots' );
+		wp_clean_themes_cache();
+
+		$this->assertTrue( wp_get_theme( $slug )->exists(), "Fixture theme {$slug} is missing from tests/fixtures/themes." );
+		switch_theme( $slug );
+
+		try {
+			$fn();
+		} finally {
+			if ( get_stylesheet() !== $previous ) {
+				switch_theme( $previous );
+			}
+		}
+	}
+
+	/**
+	 * A classic theme is exactly the case the old wp_is_block_theme() gate
+	 * excluded — so a classic site with no builder, the one with no site editor
+	 * to fall back on, got no playbook at all.
 	 */
 	public function test_the_playbooks_ship_on_a_classic_theme_with_no_builder() {
-		$this->with_no_foreign_builder(
+		$this->with_theme(
+			'saddle-classic-fixture',
 			function () {
-				$names = $this->builtin_names();
+				$this->with_no_foreign_builder(
+					function () {
+						$names = $this->builtin_names();
 
-				$this->assertContains( 'build-page', $names );
-				$this->assertContains( 'fix-page', $names );
+						$this->assertContains( 'build-page', $names );
+						$this->assertContains( 'fix-page', $names );
+					}
+				);
 			}
 		);
 	}
@@ -381,12 +419,41 @@ class Saddle_Skills_Test extends WP_UnitTestCase {
 	 * not send the agent after get-template — it would be refused.
 	 */
 	public function test_the_playbook_adapts_step_two_to_a_classic_theme() {
-		$this->with_no_foreign_builder(
+		$this->with_theme(
+			'saddle-classic-fixture',
 			function () {
-				$body = Saddle_Skills::find( 'build-page' )['body'];
+				$this->assertFalse( wp_is_block_theme(), 'The classic fixture must not read as a block theme.' );
 
-				$this->assertStringContainsString( 'classic theme', $body );
-				$this->assertStringNotContainsString( 'saddle/get-template on the header', $body );
+				$this->with_no_foreign_builder(
+					function () {
+						$body = Saddle_Skills::find( 'build-page' )['body'];
+
+						$this->assertStringContainsString( 'classic theme', $body );
+						$this->assertStringNotContainsString( 'saddle/get-template on the header', $body );
+					}
+				);
+			}
+		);
+	}
+
+	/**
+	 * The other branch, pinned for the same reason: a block theme has header
+	 * and footer parts Saddle CAN read, so step 2 sends the agent to them.
+	 */
+	public function test_the_playbook_sends_step_two_to_the_template_parts_on_a_block_theme() {
+		$this->with_theme(
+			'saddle-block-fixture',
+			function () {
+				$this->assertTrue( wp_is_block_theme(), 'The block fixture must read as a block theme.' );
+
+				$this->with_no_foreign_builder(
+					function () {
+						$body = Saddle_Skills::find( 'build-page' )['body'];
+
+						$this->assertStringContainsString( 'saddle/get-template on the header', $body );
+						$this->assertStringNotContainsString( 'this is a classic theme', $body );
+					}
+				);
 			}
 		);
 	}


### PR DESCRIPTION
Closes #145

## What
The classic-theme playbook test now switches to a classic fixture theme instead of assuming the host WordPress runs one. A block-theme fixture variant is pinned alongside it, so both branches of step 2 are tested on every machine.

## Why
`test_the_playbook_adapts_step_two_to_a_classic_theme` has been red on every CI run since 2026-08-21, on all six matrix legs, while green locally. The test's own comment said "the test site runs a CLASSIC theme". That was an environment fact, not a fixture: the harness symlinks `wp-content/themes` from the host install, which on the developer's machine is a classic theme. CI provisions a fresh core whose bundled themes are all block themes, so `wp_is_block_theme()` was true and the playbook rendered the block-theme step 2.

## How
- New `tests/fixtures/themes/saddle-classic-fixture/` (style.css + index.php). Its `index.php` and the absence of `templates/index.html` + `theme.json` are what make `wp_is_block_theme()` return false.
- New `with_theme()` helper in `skills-test.php`, mirroring the register/switch/restore pattern `site-editor-test.php` already uses. Both classic-theme tests go through it; each asserts the fixture reads as the theme type it means before checking the playbook.
- New `test_the_playbook_sends_step_two_to_the_template_parts_on_a_block_theme` pins the other branch, using the existing `saddle-block-fixture`. Passing on the developer's classic host proves the switch works in the direction CI needs.
- No production code changed.

## Testing
- [x] `composer lint` — 0 errors, the 3 pre-existing warnings
- [x] `composer test` — 654 tests (was 653), 1 pre-existing skip, locally
- [ ] CI green on all six legs — the actual fix is only proven there
