### PR TITLE
ci(release): one tag deploys the .org build to WordPress.org SVN (#176)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,13 +1,29 @@
 name: Release
 
-# Self-hosted distribution for free Saddle: on a version tag, build the
-# production zip and publish it as a GitHub Release asset (the downloadable
-# artifact). No WordPress.org / Freemius / marketplace upload involved.
+# One tag, both channels.
 #
-# Release flow:
-#   grunt bump:patch   (or minor/major) — updates the version everywhere
-#   git commit -am "release vX.Y.Z" && git tag vX.Y.Z && git push --follow-tags
-#   → this workflow builds saddle-<version>.zip and attaches it to the release.
+#   grunt version:patch   (or minor/major, or --to=x.y.z[-rcN]) — five version
+#                          sites move together; readme Stable tag only on a
+#                          real release
+#   git commit -am "chore(release): X.Y.Z" && git tag vX.Y.Z && git push --follow-tags
+#
+# → build:          verifies tag = plugin header (= readme Stable tag on a real
+#                   release), builds the WordPress.org-channel zip with the
+#                   Gruntfile's exclusion list (updater absent, no dev files),
+#                   proves those exclusions inside the artifact, and publishes a
+#                   GitHub Release (marked pre-release for -rc/-beta tags).
+# → wordpress-org:  on a real release only, pushes dist/saddle/ to SVN trunk +
+#                   tags/X.Y.Z and .wordpress.org/ listing assets to assets/.
+#                   Never runs for a pre-release tag. Needs SVN_USERNAME and
+#                   SVN_PASSWORD repository secrets — absent, it fails fast
+#                   with a named reason and the GitHub Release still stands.
+#
+# The Gruntfile is the single source of truth for what ships. There is no
+# .distignore on purpose: two exclusion lists drift, and the one that drifts
+# wrong ships the self-hosted updater to WordPress.org.
+#
+# The self-hosted channel (updater included, published to R2) is a separate,
+# deliberate step and is NOT triggered here.
 
 on:
   push:
@@ -17,23 +33,51 @@ on:
 permissions:
   contents: write
 
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
-  release:
-    name: Build & publish zip
+  build:
+    name: Build & publish GitHub Release
     runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+      prerelease: ${{ steps.version.outputs.prerelease }}
     steps:
       - uses: actions/checkout@v4
 
-      - name: Verify tag matches the plugin version
+      - name: Verify the tag, the plugin header and the readme agree
+        id: version
         run: |
+          set -euo pipefail
           TAG="${GITHUB_REF_NAME#v}"
-          HDR="$(grep -m1 -oE 'Version:[[:space:]]*[0-9.]+' saddle.php | grep -oE '[0-9.]+')"
-          echo "tag=$TAG  header=$HDR"
-          if [ "$TAG" != "$HDR" ]; then
-            echo "::error::Tag v$TAG does not match the plugin header version $HDR. Run 'grunt bump' and commit before tagging."
+          HDR="$(grep -m1 -oE 'Version:[[:space:]]*[0-9][0-9A-Za-z.-]*' saddle.php | sed -E 's/Version:[[:space:]]*//')"
+          CONST="$(grep -m1 -oE "SADDLE_VERSION',[[:space:]]*'[^']+'" saddle.php | sed -E "s/.*'([^']+)'$/\1/")"
+          STABLE="$(grep -m1 -oE 'Stable tag:[[:space:]]*[0-9][0-9A-Za-z.-]*' readme.txt | sed -E 's/Stable tag:[[:space:]]*//')"
+          echo "tag=$TAG header=$HDR constant=$CONST stable=$STABLE"
+
+          if [ "$TAG" != "$HDR" ] || [ "$TAG" != "$CONST" ]; then
+            echo "::error::Tag v$TAG does not match saddle.php (header $HDR, constant $CONST). Run 'grunt version' and commit before tagging."
             exit 1
           fi
-          echo "VERSION=$TAG" >> "$GITHUB_ENV"
+
+          if [[ "$TAG" == *-* ]]; then
+            # A release candidate must never become the Stable tag — that is
+            # the field WordPress.org serves to everyone.
+            if [ "$STABLE" = "$TAG" ]; then
+              echo "::error::readme.txt Stable tag is the pre-release $TAG. It must stay on the last real release."
+              exit 1
+            fi
+            echo "prerelease=true" >> "$GITHUB_OUTPUT"
+          else
+            if [ "$STABLE" != "$TAG" ]; then
+              echo "::error::readme.txt Stable tag is $STABLE but the release is $TAG. 'grunt version' updates it on a real release; commit that."
+              exit 1
+            fi
+            echo "prerelease=false" >> "$GITHUB_OUTPUT"
+          fi
+          echo "version=$TAG" >> "$GITHUB_OUTPUT"
 
       - uses: actions/setup-node@v4
         with:
@@ -52,12 +96,133 @@ jobs:
       - name: Build admin assets
         run: npm run build
 
-      - name: Build plugin zip
+      - name: Build the WordPress.org-channel zip
         run: npx grunt build
+
+      - name: Prove the exclusions inside the artifact
+        # The Gruntfile says what is excluded; this checks the built tree, not
+        # the config. Every line here is something that has actually been
+        # caught on a manual rebuild.
+        run: |
+          set -euo pipefail
+          D="dist/saddle"
+          test -f "$D/saddle.php" || { echo "::error::$D/saddle.php missing"; exit 1; }
+          test -f "dist/saddle-${{ steps.version.outputs.version }}.zip" || { echo "::error::zip missing"; exit 1; }
+
+          fail=0
+          check_absent() { if [ -e "$D/$1" ]; then echo "::error::$1 must not ship in the .org build"; fail=1; fi; }
+          check_absent includes/class-saddle-updater.php
+          check_absent includes/class-saddle-ecosystem.php
+          check_absent includes/lib
+          check_absent tests
+          check_absent dist
+          check_absent node_modules
+          check_absent vendor
+          check_absent .wordpress.org
+          check_absent Gruntfile.js
+          check_absent package.json
+          check_absent composer.json
+          check_absent phpcs.xml.dist
+
+          if find "$D" -name '*.md' ! -name 'LICENSE*' ! -path '*/lib/*' | grep -q .; then
+            echo "::error::Markdown files found in the .org build:"; find "$D" -name '*.md'; fail=1
+          fi
+          if find "$D" \( -name '.DS_Store' -o -name '*.log' -o -name '.git*' \) | grep -q .; then
+            echo "::error::Junk files found in the .org build"; fail=1
+          fi
+          if grep -rIl --include='*.php' -E '\b(error_log|var_dump|print_r)\s*\(' "$D" | grep -v '/lib/' | grep -q .; then
+            echo "::error::Debug output calls in the .org build:"; grep -rIl --include='*.php' -E '\b(error_log|var_dump|print_r)\s*\(' "$D"; fail=1
+          fi
+
+          # Every PHP file parses on the runner's PHP.
+          if ! find "$D" -name '*.php' -print0 | xargs -0 -n1 php -l >/dev/null; then
+            echo "::error::A PHP file in the .org build does not parse"; fail=1
+          fi
+
+          [ "$fail" -eq 0 ]
+          echo "OK: $(find "$D" -type f | wc -l) files"
+
+      - name: Keep the built tree for the deploy job
+        uses: actions/upload-artifact@v4
+        with:
+          name: saddle-wporg-build
+          path: dist/saddle
+          if-no-files-found: error
+          retention-days: 7
 
       - name: Publish GitHub Release
         uses: softprops/action-gh-release@v2
         with:
-          files: dist/saddle-${{ env.VERSION }}.zip
+          files: dist/saddle-${{ steps.version.outputs.version }}.zip
           fail_on_unmatched_files: true
           generate_release_notes: true
+          prerelease: ${{ steps.version.outputs.prerelease == 'true' }}
+
+  wordpress-org:
+    name: Deploy to WordPress.org SVN
+    needs: build
+    if: needs.build.outputs.prerelease == 'false'
+    runs-on: ubuntu-latest
+    # A GitHub Environment. Created on first run; add a required reviewer under
+    # Settings → Environments → wordpress-org if you ever want a manual gate
+    # in front of SVN without touching this file.
+    environment: wordpress-org
+    steps:
+      - name: Require the SVN secrets
+        env:
+          SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
+          SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
+        run: |
+          if [ -z "$SVN_USERNAME" ] || [ -z "$SVN_PASSWORD" ]; then
+            echo "::error::SVN_USERNAME / SVN_PASSWORD are not set. Add them under Settings → Secrets (the wp.org account that owns the plugin — 'badhonrocks' per readme Contributors). The GitHub Release is published; only the SVN deploy is skipped."
+            exit 1
+          fi
+
+      - uses: actions/checkout@v4
+        # Only for .wordpress.org/ — the plugin tree comes from the artifact so
+        # SVN receives exactly what the Release zip contains.
+
+      - name: Fetch the built tree
+        uses: actions/download-artifact@v4
+        with:
+          name: saddle-wporg-build
+          path: build
+
+      - name: Stage the listing assets
+        # .wordpress.org/ carries a README and the banner's SVG source, which
+        # must not land in SVN assets/ — that folder is served as-is. Only the
+        # files the directory understands are copied.
+        run: |
+          set -euo pipefail
+          mkdir -p wporg-assets
+          shopt -s nullglob
+          for f in .wordpress.org/icon-*.png .wordpress.org/icon.svg .wordpress.org/banner-*.png .wordpress.org/screenshot-*.png .wordpress.org/screenshot-*.jpg; do
+            cp "$f" wporg-assets/
+          done
+          ls -la wporg-assets
+
+      - name: Install Subversion
+        # ubuntu-24.04 runners no longer ship svn.
+        run: sudo apt-get update -q && sudo apt-get install -y -q subversion
+
+      - name: Deploy to SVN
+        uses: 10up/action-wordpress-plugin-deploy@stable
+        env:
+          SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
+          SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
+          SLUG: saddle
+          VERSION: ${{ needs.build.outputs.version }}
+          # BUILD_DIR makes the action rsync this tree into trunk/ verbatim and
+          # ignore .distignore. The Gruntfile already applied every exclusion.
+          BUILD_DIR: build
+          ASSETS_DIR: wporg-assets
+
+      - name: Summary
+        run: |
+          {
+            echo "## Deployed saddle ${{ needs.build.outputs.version }} to WordPress.org"
+            echo
+            echo "- trunk and tags/${{ needs.build.outputs.version }} updated from the Release build"
+            echo "- listing assets synced from .wordpress.org/"
+            echo "- https://wordpress.org/plugins/saddle/"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.wordpress.org/README.md
+++ b/.wordpress.org/README.md
@@ -26,11 +26,17 @@ the same trademark rule as the plugin name — the round-1 review called out
 "graphic resources such as this plugin icons and banners" explicitly. It now
 reads "Control your site with AI — safely."
 
-After the plugin is approved, copy these into the SVN repo:
+After the plugin is approved these are synced to SVN `assets/` automatically by
+`.github/workflows/release.yml` on every real release tag (#176). Only
+`icon*.png`, `icon.svg`, `banner-*.png` and `screenshot-*.{png,jpg}` are copied;
+this README and `src/` never leave the repo.
+
+Manual fallback, if ever needed:
 
     svn co https://plugins.svn.wordpress.org/saddle
-    cp .wordpress.org/icon* .wordpress.org/banner* saddle/assets/
+    cp .wordpress.org/icon* .wordpress.org/banner* .wordpress.org/screenshot-* saddle/assets/
     svn add saddle/assets/* && svn ci -m "Listing assets"
 
 Screenshots (`screenshot-N.png` + captions in readme.txt) are still to be
-captured from a live wp-admin before or after approval.
+captured from a live wp-admin. Drop them in this folder and they ship with the
+next release.

--- a/WPORG-SUBMISSION.md
+++ b/WPORG-SUBMISSION.md
@@ -32,10 +32,35 @@ because nothing in this plugin can make it stop being flagged.
    plus banner/icon. Screenshots do NOT go in the zip.
    **Banner + icon are ready** in `.wordpress.org/` (icon.svg,
    icon-128/256 PNGs, banner-772x250 + banner-1544x500 — generated 2026-07-25
-   from the disc brand mark; see `.wordpress.org/README.md` for the SVN copy
-   commands). Only the screenshots remain to be captured.
+   from the disc brand mark). Only the screenshots remain to be captured —
+   drop them in `.wordpress.org/` as `screenshot-N.png` and they ship with
+   the next release automatically.
 4. First public GitHub tag/release only AFTER wp.org approval (CLAUDE.md
    distribution rule).
+
+### After approval: releases are automated (2026-09-07, #176)
+
+Once the SVN repo exists, **every update is one tag.** `.github/workflows/release.yml`:
+
+1. `grunt version:patch` (or `minor` / `major` / `--to=x.y.z`), commit, `git tag vX.Y.Z`,
+   `git push --follow-tags`. Version bumps still need Fahim's OK (CLAUDE.md).
+2. CI verifies tag = plugin header = `SADDLE_VERSION` = readme `Stable tag`, builds
+   the .org-channel zip with the Gruntfile's exclusions, **proves the exclusions
+   inside the artifact** (no updater, no `includes/lib`, no tests/docs/dev files,
+   no debug calls, every PHP file parses), and publishes the GitHub Release.
+3. On a real release (no `-rc`/`-beta` suffix) it then deploys `dist/saddle/` to
+   SVN `trunk/` + `tags/X.Y.Z` and `.wordpress.org/` icons, banners and
+   screenshots to `assets/`. A pre-release tag publishes the GitHub Release only
+   and never touches SVN.
+
+**One-time setup, after approval:** add repository secrets `SVN_USERNAME` and
+`SVN_PASSWORD` for the wp.org account that owns the plugin (Settings → Secrets and
+variables → Actions). Until they exist the SVN job fails with a named reason and
+the GitHub Release still stands. Optional: Settings → Environments →
+`wordpress-org` → add a required reviewer for a manual gate in front of SVN.
+
+There is deliberately **no `.distignore`**: the Gruntfile is the only exclusion
+list, so the two channels cannot drift apart.
 
 ## Pre-written answers for likely reviewer questions
 


### PR DESCRIPTION
Closes #176

## What
A `vX.Y.Z` tag now does the whole release: verify versions agree → build the WordPress.org-channel zip → prove the exclusions inside the artifact → GitHub Release → on a real release, deploy to WordPress.org SVN (trunk + tag + listing assets). Pre-release tags stop after the GitHub Release and never touch SVN.

## Why
The .org zip was rebuilt by hand three times in two weeks, each time with a temporary header edit and a checklist that is only in a markdown file. After approval every update would add an SVN commit to that. One tag should do it, with the Gruntfile's exclusion list as the only exclusion list.

## How
- **Single source of exclusions.** `BUILD_DIR=dist/saddle` makes `10up/action-wordpress-plugin-deploy` rsync the Gruntfile's staged tree verbatim and ignore `.distignore`. There is deliberately no `.distignore` — two lists drift, and the one that drifts wrong ships the self-hosted updater to .org.
- **Proof, not trust.** A step checks the built tree: updater absent, `includes/lib` absent, no tests/docs/dev files, no `*.md` except licenses, no `.DS_Store`/logs, no `error_log`/`var_dump`/`print_r`, every PHP file parses. Every line is something a manual rebuild has actually caught. Verified against today's real 103-file build: zero false positives.
- **Version guard extended.** Tag must equal the header *and* `SADDLE_VERSION`, and on a real release the readme `Stable tag`. An `-rc` tag is refused if it has become the Stable tag.
- **Assets staged, not copied wholesale.** Only `icon*`, `banner-*` and `screenshot-*` from `.wordpress.org/` reach SVN `assets/`; the README and banner source stay in the repo.
- **Fails fast without secrets.** `SVN_USERNAME`/`SVN_PASSWORD` are checked first with a message naming where to add them. The GitHub Release is already published by then.
- Runs under a `wordpress-org` GitHub Environment, so a required reviewer can be added later as a manual gate without editing the workflow.
- `svn` installed explicitly; ubuntu-24.04 runners no longer ship it.
- Self-hosted channel (R2, updater included) is untouched and not triggered here.

## Testing
- [x] `actionlint` 1.7.7 — clean
- [x] Artifact-proof script run locally against `dist/saddle` (the Aug 27 .org build) — `fail=0`, 103 files
- [ ] Real run needs a tag; the SVN job also needs wp.org approval (no SVN repo yet) and the two secrets. Until then a tag exercises `build` fully and `wordpress-org` fails at the secrets check by design.

## One-time setup after approval
Settings → Secrets → `SVN_USERNAME`, `SVN_PASSWORD` for the account in readme `Contributors:`.
